### PR TITLE
Reuse NestedChoice in the definition of 2ADT

### DIFF
--- a/src/Framework/V2/Constructs/NestedChoice.agda
+++ b/src/Framework/V2/Constructs/NestedChoice.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --sized-types #-}
+
+open import Framework.V2.Definitions
+
+module Framework.V2.Constructs.NestedChoice (F : 𝔽) where
+
+open import Data.String using (String)
+open import Size using (Size; ↑_)
+
+import Framework.V2.Constructs.Choices as Chc
+open Chc.Choice₂ renaming (Syntax to 2Choice; Standard-Semantics to ⟦_⟧₂; Config to Config₂; show to show-2choice)
+
+data NestedChoice : Size → 𝔼 where
+  value  : ∀ {i A} → A → NestedChoice i A
+  choice : ∀ {i A} → 2Choice F (NestedChoice i A) → NestedChoice (↑ i) A
+
+⟦_⟧ : ∀ {i A} → NestedChoice i A → Config₂ F → A
+⟦ value  v   ⟧ c = v
+⟦ choice chc ⟧ c = ⟦ ⟦ chc ⟧₂ c ⟧ c
+
+show-nested-choice : ∀ {i A} → (F → String) → (A → String) → NestedChoice i A → String
+show-nested-choice show-q show-carrier ( value v) = show-carrier v
+show-nested-choice show-q show-carrier (choice c) =
+  show-2choice
+    show-q
+    (show-nested-choice show-q show-carrier)
+    c

--- a/src/Framework/V2/Lang/2ADT.agda
+++ b/src/Framework/V2/Lang/2ADT.agda
@@ -10,21 +10,19 @@ open import Size using (Size; ↑_)
 
 open import Framework.V2.Constructs.GrulerArtifacts
 open import Framework.V2.Constructs.Choices
+open import Framework.V2.Constructs.NestedChoice F public
 open import Framework.V2.Variants using (GrulerVariant)
 
 private
   Choice₂ = VLChoice₂.Syntax
   Config₂ = Choice₂.Config
-  choice₂-semantics = VLChoice₂.Semantics
 
-data 2ADT : Size → 𝔼 where
-  2ADTAsset  : ∀ {i A} → Leaf A → 2ADT i A
-  2ADTChoice : ∀ {i A} → Choice₂ F (2ADT i) A → 2ADT (↑ i) A
+2ADT : Size → 𝔼
+2ADT i A = NestedChoice i (Leaf A)
 
 mutual
   2ADTVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant F Config₂
   2ADTVL {i} = syn 2ADT i with-sem semantics
 
   semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant F Config₂ (2ADT i)
-  semantics (2ADTAsset a) _  = VLLeaf.elim-leaf F VLLeaf.Leaf∈ₛGrulerVariant a
-  semantics (2ADTChoice chc) = choice₂-semantics GrulerVariant F id 2ADTVL chc
+  semantics e c = VLLeaf.elim-leaf F VLLeaf.Leaf∈ₛGrulerVariant (⟦ e ⟧ c)

--- a/src/Framework/V2/TODO.lagda.md
+++ b/src/Framework/V2/TODO.lagda.md
@@ -11,8 +11,7 @@ open import Framework.V2.Definitions
 import Framework.V2.Constructs.Choices as Chc
 open Chc.VLChoice₂ renaming (Syntax to 2Choice)
 
-import Framework.V2.Translation.Construct.NChoice-to-2Choice as N→2
-open N→2.Translate using (NestedChoice)
+open import Framework.V2.Constructs.NestedChoice using (NestedChoice)
 ```
 
 # TODOs for Framework V.2
@@ -47,7 +46,7 @@ postulate
   embed : ∀ {V F S A} {i}
     → (Γ : VariabilityLanguage V F S)
     → F ⊢ 2Choice ∈ₛ Expression Γ
-    → NestedChoice {F} (Eq.setoid (Expression Γ A)) i
+    → NestedChoice F i (Expression Γ A)
     → Expression Γ A
 ```
 

--- a/src/Framework/V2/Translation/Lang/2ADT-to-NADT.agda
+++ b/src/Framework/V2/Translation/Lang/2ADT-to-NADT.agda
@@ -23,8 +23,8 @@ import Framework.V2.Translation.Construct.2Choice-to-NChoice {F} as 2→N
 open 2→N.Translate using (convert)
 
 compile : ∀ {i} → 2ADT F i A → NADT F i A
-compile (2ADTAsset a)      = NADTAsset a
-compile (2ADTChoice {i} c) = NADTChoice (mapₙ compile (convert (Eq.setoid (2ADT F i A)) c))
+compile (value a)      = NADTAsset a
+compile (choice {i} c) = NADTChoice (mapₙ compile (convert (Eq.setoid (2ADT F i A)) c))
 
 module Preservation where
   -- open Data.IndexedSet (VariantSetoid GrulerVariant A) using () renaming (_≅_ to _≋_)
@@ -33,21 +33,21 @@ module Preservation where
   -- open 2→N.Translate.Preservation 2ADTVL NADTVL compile conf' fnoc' using (preserves-conf; preserves-fnoc)
 
   -- preserves-l : ∀ (e : 2ADT A) → Conf-Preserves 2ADTVL NADTVL e (compile e) conf'
-  -- preserves-l (2ADTAsset _) _ = refl
-  -- preserves-l (2ADTChoice (D ⟨ l , r ⟩)) c =
+  -- preserves-l (value _) _ = refl
+  -- preserves-l (choice (D ⟨ l , r ⟩)) c =
   --   begin
-  --     ⟦ 2ADTChoice (D ⟨ l , r ⟩) ⟧-2adt c
+  --     ⟦ choice (D ⟨ l , r ⟩) ⟧-2adt c
   --   ≡⟨⟩
   --     BinaryChoice-Semantics 2ADTVL (D ⟨ l , r ⟩) c
   --   ≡⟨ preserves-conf D l r (default-conf-satisfies-spec D) (preserves-l l) (preserves-l r) c ⟩
   --     Choice-Semantics NADTVL (convert (D ⟨ l , r ⟩)) (conf' c)
   --   ≡⟨⟩
-  --     ⟦ compile (2ADTChoice (D ⟨ l , r ⟩)) ⟧-nadt (conf' c)
+  --     ⟦ compile (choice (D ⟨ l , r ⟩)) ⟧-nadt (conf' c)
   --   ∎
 
   -- preserves-r : ∀ (e : 2ADT A) → Fnoc-Preserves 2ADTVL NADTVL e (compile e) fnoc'
-  -- preserves-r (2ADTAsset _) _ = refl
-  -- preserves-r (2ADTChoice (D ⟨ l , r ⟩)) c = preserves-fnoc D l r (default-fnoc-satisfies-spec D) (preserves-r l) (preserves-r r) c
+  -- preserves-r (value _) _ = refl
+  -- preserves-r (choice (D ⟨ l , r ⟩)) c = preserves-fnoc D l r (default-fnoc-satisfies-spec D) (preserves-r l) (preserves-r r) c
 
   -- preserves : ∀ (e : 2ADT A) → ⟦ e ⟧-2adt ≋ ⟦ compile e ⟧-nadt
   -- preserves e = ⊆-by-index-translation conf' (preserves-l e)


### PR DESCRIPTION
The other way around (replacing `NestedChoice` with `2ADT`) isn't possible because `2ADT` fixes the semantics to `GrulerVariant`s.

This PR depends on #5 because both modify the file [src/Framework/V2/Translation/Construct/NChoice-to-2Choice.agda](https://github.com/pmbittner/AgdaCCnOC/compare/embed-NestedChoice...reuse-NestedChoice?expand=1#diff-03f4cb0d9a75d5472cf03e4fdd85aa2f93010ca6873ab183f8ece48878af28ed)