### PR TITLE
Remove annotation language abstraction

### DIFF
--- a/src/Framework/V2/Compiler.agda
+++ b/src/Framework/V2/Compiler.agda
@@ -6,23 +6,23 @@ open import Relation.Binary.PropositionalEquality as Eq using (_≗_)
 open import Data.Product using (_×_)
 open import Function using (id; _∘_)
 
-ConfigTranslation : ∀ (F₁ : 𝔽) (S₁ : 𝕊) (F₂ : 𝔽) (S₂ : 𝕊) → Set
-ConfigTranslation F₁ S₁ F₂ S₂ = S₁ F₁ → S₂ F₂
+ConfigTranslation : ∀ (S₁ : 𝕊) (S₂ : 𝕊) → Set
+ConfigTranslation S₁ S₂ = S₁ → S₂
 
-record ConfigCompiler (F₁ : 𝔽) (S₁ : 𝕊) (F₂ : 𝔽) (S₂ : 𝕊) : Set where
+record ConfigCompiler (S₁ : 𝕊) (S₂ : 𝕊) : Set where
   field
-    to   : ConfigTranslation F₁ S₁ F₂ S₂
-    from : ConfigTranslation F₂ S₂ F₁ S₁
+    to   : ConfigTranslation S₁ S₂
+    from : ConfigTranslation S₂ S₁
 open ConfigCompiler public
 
 {-|
 A translated configuration is extensionally equal.
 Fixme: Give me a proper name not this ugly one.
 -}
-ExtensionallyEqual-Translation : ∀ {F S Sel} → ConfigEvaluator F S Sel → ConfigTranslation F S F S → Set
+ExtensionallyEqual-Translation : ∀ {F S Sel} → ConfigEvaluator F S Sel → ConfigTranslation S S → Set
 ExtensionallyEqual-Translation evalConfig f = ∀ c → evalConfig (f c) ≗ evalConfig c
 
-ExtensionallyEqual : ∀ {F S Sel} → ConfigEvaluator F S Sel → ConfigCompiler F S F S → Set
+ExtensionallyEqual : ∀ {F S Sel} → ConfigEvaluator F S Sel → ConfigCompiler S S → Set
 ExtensionallyEqual {F} {S} evalConfig record { to = to ; from = from } =
   ExtensionallyEqual-Translation {F} {S} evalConfig to × ExtensionallyEqual-Translation {F} {S} evalConfig from
 
@@ -30,10 +30,10 @@ ExtensionallyEqual {F} {S} evalConfig record { to = to ; from = from } =
 -- (i.e., if `to` is an embedding into the second configuration language via its inverse `from`).
 -- We do not require the inverse direction `from`, being an embedding of configurations from `C₂` into `C₁`, because `C₂` could be larger than `C₁` (when interpreted as a set).
 -- For example, the set of features in `C₂` could be bigger (e.g., when going from core choice calculus to binary choice calculus) but all information can be derived by `conf` from our initial configuration `c₁`.
-Stable : ∀ {F₁ S₁ F₂ S₂} → ConfigCompiler F₁ S₁ F₂ S₂ → Set
+Stable : ∀ {S₁ S₂} → ConfigCompiler S₁ S₂ → Set
 Stable cc = from cc ∘ to cc ≗ id
 
-record LanguageCompiler {V F₁ F₂ S₁ S₂} (Γ₁ : VariabilityLanguage V F₁ S₁) (Γ₂ : VariabilityLanguage V F₂ S₂) : Set₁ where
+record LanguageCompiler {V S₁ S₂} (Γ₁ : VariabilityLanguage V S₁) (Γ₂ : VariabilityLanguage V S₂) : Set₁ where
   private
     L₁ = Expression Γ₁
     L₂ = Expression Γ₂
@@ -42,7 +42,7 @@ record LanguageCompiler {V F₁ F₂ S₁ S₂} (Γ₁ : VariabilityLanguage V F
 
   field
     compile         : ∀ {A} → L₁ A → L₂ A
-    config-compiler : ConfigCompiler F₁ S₁ F₂ S₂
+    config-compiler : ConfigCompiler S₁ S₂
     preserves : ∀ {A} → let open IVSet V A using (_≅[_][_]_) in
                 ∀ (e : L₁ A) → ⟦ e ⟧₁ ≅[ to config-compiler ][ from config-compiler ] ⟦ compile e ⟧₂
                 -- TODO: It might nice to have syntax
@@ -58,16 +58,16 @@ record LanguageCompiler {V F₁ F₂ S₁ S₂} (Γ₁ : VariabilityLanguage V F
 --        To preserve semantics, most of the time, additional requirements on the
 --        config translations are required which are currently not part of the
 --        preservation theorem here. Maybe we have to add these constraints as type parameters here?
-record ConstructCompiler {V F₁ S₁ F₂ S₂} (VC₁ : VariabilityConstruct V F₁ S₁) (VC₂ : VariabilityConstruct V F₂ S₂) : Set₁ where
+record ConstructCompiler {V S₁ S₂} (VC₁ : VariabilityConstruct V S₁) (VC₂ : VariabilityConstruct V S₂) : Set₁ where
   open VariabilityConstruct VC₁ renaming (Construct to C₁; construct-semantics to sem₁)
   open VariabilityConstruct VC₂ renaming (Construct to C₂; construct-semantics to sem₂)
 
   field
-    compile : ∀ {E A} → C₁ F₁ E A → C₂ F₂ E A
-    config-compiler : ConfigCompiler F₁ S₁ F₂ S₂
+    compile : ∀ {E A} → C₁ E A → C₂ E A
+    config-compiler : ConfigCompiler S₁ S₂
     stable : Stable config-compiler
-    preserves : ∀ {Γ : VariabilityLanguage V F₁ S₁} {A}
-      → (c : C₁ F₁ (Expression Γ) A)
+    preserves : ∀ {Γ : VariabilityLanguage V S₁} {A}
+      → (c : C₁ (Expression Γ) A)
       → let open IVSet V A using (_≅_) in
         sem₁ id Γ c ≅ sem₂ (to config-compiler) Γ (compile c)
 
@@ -76,36 +76,36 @@ Compiles languages below constructs.
 This means that an expression in a language Γ₁ of which we know that it has a specific
 syntactic construct VC at the top is compiled to Γ₂ retaining the very same construct at the top.
 -}
-record ConstructFunctor {V F S} (VC : VariabilityConstruct V F S) : Set₁ where
+record ConstructFunctor {V S} (VC : VariabilityConstruct V S) : Set₁ where
   open VariabilityConstruct VC
   open LanguageCompiler using (conf; fnoc; compile; config-compiler)
 
   field
     map : ∀ {A} {L₁ L₂ : 𝔼}
       → (L₁ A → L₂ A)
-      → Construct F L₁ A
-      → Construct F L₂ A
-    preserves : ∀ {F'} {S'} {Γ₁ : VariabilityLanguage V F S} {Γ₂ : VariabilityLanguage V F' S'} {A}
+      → Construct L₁ A
+      → Construct L₂ A
+    preserves : ∀ {S'} {Γ₁ : VariabilityLanguage V S} {Γ₂ : VariabilityLanguage V S'} {A}
       → let open IVSet V A using (_≅[_][_]_) in
       ∀ (t : LanguageCompiler Γ₁ Γ₂)
-      → (c : Construct F (Expression Γ₁) A)
+      → (c : Construct (Expression Γ₁) A)
       → Stable (config-compiler t)
       → construct-semantics id Γ₁ c
           ≅[ conf t ][ fnoc t ]
         construct-semantics (fnoc t) Γ₂ (map (compile t) c)
 
-_⊕ᶜᶜ_ : ∀ {F₁ F₂ F₃} {S₁ S₂ S₃}
-  → ConfigCompiler F₁ S₁ F₂ S₂
-  → ConfigCompiler F₂ S₂ F₃ S₃
-  → ConfigCompiler F₁ S₁ F₃ S₃
+_⊕ᶜᶜ_ : ∀ {S₁ S₂ S₃}
+  → ConfigCompiler S₁ S₂
+  → ConfigCompiler S₂ S₃
+  → ConfigCompiler S₁ S₃
 1→2 ⊕ᶜᶜ 2→3 = record
   { to   = to   2→3 ∘ to   1→2
   ; from = from 1→2 ∘ from 2→3
   }
 
 ⊕ᶜᶜ-stable :
-  ∀ {F₁ F₂ F₃} {S₁ S₂ S₃}
-    (1→2 : ConfigCompiler F₁ S₁ F₂ S₂) (2→3 : ConfigCompiler F₂ S₂ F₃ S₃)
+  ∀ {S₁ S₂ S₃}
+    (1→2 : ConfigCompiler S₁ S₂) (2→3 : ConfigCompiler S₂ S₃)
   → Stable 1→2
   → Stable 2→3
     --------------------
@@ -124,14 +124,14 @@ _⊕ᶜᶜ_ : ∀ {F₁ F₂ F₃} {S₁ S₂ S₃}
     id c₁
   ∎
 
-_⊕ˡ_ : ∀ {V} {F₁ F₂ F₃} {S₁ S₂ S₃}
-        {Γ₁ : VariabilityLanguage V F₁ S₁}
-        {Γ₂ : VariabilityLanguage V F₂ S₂}
-        {Γ₃ : VariabilityLanguage V F₃ S₃}
+_⊕ˡ_ : ∀ {V} {S₁ S₂ S₃}
+        {Γ₁ : VariabilityLanguage V S₁}
+        {Γ₂ : VariabilityLanguage V S₂}
+        {Γ₃ : VariabilityLanguage V S₃}
       → LanguageCompiler Γ₁ Γ₂
       → LanguageCompiler Γ₂ Γ₃
       → LanguageCompiler Γ₁ Γ₃
-_⊕ˡ_ {V} {F₁} {F₂} {F₃} {S₁} {S₂} {S₃} {Γ₁} {Γ₂} {Γ₃} L₁→L₂ L₂→L₃ = record
+_⊕ˡ_ {V} {S₁} {S₂} {S₃} {Γ₁} {Γ₂} {Γ₃} L₁→L₂ L₂→L₃ = record
   { compile = compile L₂→L₃ ∘ compile L₁→L₂
   ; config-compiler = record { to = conf'; from = fnoc' }
   ; preserves = p
@@ -141,10 +141,10 @@ _⊕ˡ_ {V} {F₁} {F₂} {F₃} {S₁} {S₂} {S₃} {Γ₁} {Γ₂} {Γ₃} L�
         ⟦_⟧₁ = Semantics Γ₁
         ⟦_⟧₃ = Semantics Γ₃
 
-        conf' : S₁ F₁ → S₃ F₃
+        conf' : S₁ → S₃
         conf' = conf L₂→L₃ ∘ conf L₁→L₂
 
-        fnoc' : S₃ F₃ → S₁ F₁
+        fnoc' : S₃ → S₁
         fnoc' = fnoc L₁→L₂ ∘ fnoc L₂→L₃
 
         module _ {A : 𝔸} where

--- a/src/Framework/V2/Constructs/Artifact.agda
+++ b/src/Framework/V2/Constructs/Artifact.agda
@@ -16,23 +16,23 @@ import Data.IndexedSet
 open import Framework.V2.Constructs.Plain.Artifact public
 
 Syntax : ℂ
-Syntax _ E A = Artifact A (E A)
+Syntax E A = Artifact A (E A)
 
-Semantics : ∀ {V : 𝕍} (F : 𝔽) (S : 𝕊)
-  → F ⊢ Syntax ∈ₛ V
-  → ℂ-Semantics V F S Syntax
-Semantics _ _ V-has-Artifact conf-comp (syn _ with-sem ⟦_⟧) a c
+Semantics : ∀ {V : 𝕍} (S : 𝕊)
+  → Syntax ∈ₛ V
+  → ℂ-Semantics V S Syntax
+Semantics _ V-has-Artifact conf-comp (syn _ with-sem ⟦_⟧) a c
   = cons V-has-Artifact (map-children (λ e → ⟦ e ⟧ c) a)
 
-map-children-preserves : ∀ {V : 𝕍} {F₁ F₂ : 𝔽} {S₁ S₂ : 𝕊} {Γ₁ : VariabilityLanguage V F₁ S₁} {Γ₂ : VariabilityLanguage V F₂ S₂} {A}
+map-children-preserves : ∀ {V : 𝕍} {S₁ S₂ : 𝕊} {Γ₁ : VariabilityLanguage V S₁} {Γ₂ : VariabilityLanguage V S₂} {A}
   → let open IVSet V A using (_≅_; _≅[_][_]_) in
-  ∀ (mkArtifact : F₁ ⊢ Syntax ∈ₛ V)
+  ∀ (mkArtifact : Syntax ∈ₛ V)
   → (t : LanguageCompiler Γ₁ Γ₂)
-  → (at : Syntax F₁ (Expression Γ₁) A)
-  → Semantics F₁ S₁ mkArtifact id Γ₁ at
+  → (at : Syntax (Expression Γ₁) A)
+  → Semantics S₁ mkArtifact id Γ₁ at
       ≅[ conf t ][ fnoc t ]
-    Semantics F₁ S₁ mkArtifact (fnoc t) Γ₂ (map-children (compile t) at)
-map-children-preserves {V} {F₁} {F₂} {S₁} {S₂} {Γ₁} {Γ₂} {A} mkArtifact t (a -< cs >-) =
+    Semantics S₁ mkArtifact (fnoc t) Γ₂ (map-children (compile t) at)
+map-children-preserves {V} {S₁} {S₂} {Γ₁} {Γ₂} {A} mkArtifact t (a -< cs >-) =
     ≅[]-begin
       (λ c → cons mkArtifact (a -< map (λ e → ⟦ e ⟧₁ c) cs >-))
     ≅[]⟨ t-⊆ , t-⊇ ⟩

--- a/src/Framework/V2/Constructs/Choices.agda
+++ b/src/Framework/V2/Constructs/Choices.agda
@@ -164,7 +164,7 @@ open import Framework.V2.Definitions as Defs hiding (Semantics)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Function using (id)
 
-module VLChoice₂ where
+module VLChoice₂ (F : Set) where
   open Choice₂ using (_⟨_,_⟩; Config; Standard-Semantics; map; map-preserves)
   open Choice₂.Syntax using (dim)
 
@@ -172,25 +172,25 @@ module VLChoice₂ where
   open LanguageCompiler
 
   Syntax : ℂ
-  Syntax F E A = Choice₂.Syntax F (E A)
+  Syntax E A = Choice₂.Syntax F (E A)
 
-  Semantics : ∀ (V : 𝕍) (F : 𝔽) → ℂ-Semantics V F Config Syntax
-  Semantics _ _ fnoc (syn _ with-sem ⟦_⟧) chc c = ⟦ Standard-Semantics chc (fnoc c) ⟧ c
+  Semantics : ∀ (V : 𝕍) → ℂ-Semantics V (Config F) Syntax
+  Semantics _ fnoc (syn _ with-sem ⟦_⟧) chc c = ⟦ Standard-Semantics chc (fnoc c) ⟧ c
 
-  Construct : ∀ (V : 𝕍) (F : 𝔽) → VariabilityConstruct V F Config
-  Construct V F = con Syntax with-sem Semantics V F
+  Construct : ∀ (V : 𝕍) → VariabilityConstruct V (Config F)
+  Construct V = con Syntax with-sem Semantics V
 
-  map-compile-preserves : ∀ {V} {F₁ F₂ : 𝔽} {S₂ : 𝕊} {Γ₁ : VariabilityLanguage V F₁ Config} {Γ₂ : VariabilityLanguage V F₂ S₂} {A}
+  map-compile-preserves : ∀ {V} {S₂ : 𝕊} {Γ₁ : VariabilityLanguage V (Config F)} {Γ₂ : VariabilityLanguage V S₂} {A}
     → let open IVSet V A using (_≅_; _≅[_][_]_) in
     ∀ (t : LanguageCompiler Γ₁ Γ₂)
-    → (chc : Syntax F₁ (Expression Γ₁) A)
+    → (chc : Syntax (Expression Γ₁) A)
     → Stable (config-compiler t)
-    → Semantics V F₁ id Γ₁ chc
+    → Semantics V id Γ₁ chc
         ≅[ conf t ][ fnoc t ]
-      Semantics V F₁ (fnoc t) Γ₂ (map (compile t) chc)
-  map-compile-preserves {V} {F₁} {_} {_} {Γ₁} {Γ₂} {A} t chc stable =
+      Semantics V (fnoc t) Γ₂ (map (compile t) chc)
+  map-compile-preserves {V} {_} {Γ₁} {Γ₂} {A} t chc stable =
     ≅[]-begin
-      Semantics V F₁ id Γ₁ chc
+      Semantics V id Γ₁ chc
     ≅[]⟨⟩
       (λ c → ⟦ Standard-Semantics chc c ⟧₁ c)
     -- First compiler proof composition:
@@ -203,7 +203,7 @@ module VLChoice₂ where
     ≐˘[ c ]⟨ Eq.cong (λ x → ⟦ x ⟧₂ c) (map-preserves (compile t) chc (fnoc t c)) ⟩
       (λ c → ⟦ Standard-Semantics (map (compile t) chc) (fnoc t c) ⟧₂ c)
     ≅[]⟨⟩
-      Semantics V F₁ (fnoc t) Γ₂ (map (compile t) chc)
+      Semantics V (fnoc t) Γ₂ (map (compile t) chc)
     ≅[]-∎
     where module I = IVSet V A
           open I using (_≅[_][_]_; _⊆[_]_)
@@ -238,13 +238,13 @@ module VLChoice₂ where
               (λ c → ⟦ Standard-Semantics chc c ⟧₁ c) (fnoc t i)
             ∎
 
-  cong-compiler : ∀ V F → ConstructFunctor (Construct V F)
-  cong-compiler _ _ = record
+  cong-compiler : ∀ V → ConstructFunctor (Construct V)
+  cong-compiler _ = record
     { map = map
     ; preserves = map-compile-preserves
     }
 
-module VLChoiceₙ where
+module VLChoiceₙ (Q : Set) where
   open Choiceₙ using (_⟨_⟩; Config; Standard-Semantics; map; map-preserves)
   open Choiceₙ.Syntax using (dim)
 
@@ -252,13 +252,13 @@ module VLChoiceₙ where
   open LanguageCompiler
 
   Syntax : ℂ
-  Syntax F E A = Choiceₙ.Syntax F (E A)
+  Syntax E A = Choiceₙ.Syntax Q (E A)
 
-  Semantics : ∀ (V : 𝕍) (F : 𝔽) → ℂ-Semantics V F Config Syntax
-  Semantics _ _ fnoc (syn E with-sem ⟦_⟧) choice c = ⟦ Choiceₙ.Standard-Semantics choice (fnoc c) ⟧ c
+  Semantics : ∀ (V : 𝕍) → ℂ-Semantics V (Config Q) Syntax
+  Semantics _ fnoc (syn E with-sem ⟦_⟧) choice c = ⟦ Choiceₙ.Standard-Semantics choice (fnoc c) ⟧ c
 
-  Construct : ∀ (V : 𝕍) (F : 𝔽) → VariabilityConstruct V F Config
-  Construct V F = con Syntax with-sem Semantics V F
+  Construct : ∀ (V : 𝕍) → VariabilityConstruct V (Config Q)
+  Construct V = con Syntax with-sem Semantics V
 
   -- Interestingly, this proof is entirely copy and paste from VLChoice₂.map-compile-preserves.
   -- Only minor adjustments to adapt the theorem had to be made.
@@ -266,17 +266,17 @@ module VLChoiceₙ where
   -- This proof is oblivious of at least
   --   - the implementation of map, we only need the preservation theorem
   --   - the Standard-Semantics, we only need the preservation theorem of t, and that the config-compiler is stable.
-  map-compile-preserves : ∀ {V} {F₁ F₂ : 𝔽} {S₂ : 𝕊} {Γ₁ : VariabilityLanguage V F₁ Config} {Γ₂ : VariabilityLanguage V F₂ S₂} {A}
+  map-compile-preserves : ∀ {V} {S₂ : 𝕊} {Γ₁ : VariabilityLanguage V (Config Q)} {Γ₂ : VariabilityLanguage V S₂} {A}
     → let open IVSet V A using (_≅_; _≅[_][_]_) in
     ∀ (t : LanguageCompiler Γ₁ Γ₂)
-    → (chc : Syntax F₁ (Expression Γ₁) A)
+    → (chc : Syntax (Expression Γ₁) A)
     → Stable (config-compiler t)
-    → Semantics V F₁ id Γ₁ chc
+    → Semantics V id Γ₁ chc
         ≅[ conf t ][ fnoc t ]
-      Semantics V F₁ (fnoc t) Γ₂ (map (compile t) chc)
-  map-compile-preserves {V} {F₁} {_} {_} {Γ₁} {Γ₂} {A} t chc stable =
+      Semantics V (fnoc t) Γ₂ (map (compile t) chc)
+  map-compile-preserves {V} {_} {Γ₁} {Γ₂} {A} t chc stable =
     ≅[]-begin
-      Semantics V F₁ id Γ₁ chc
+      Semantics V id Γ₁ chc
     ≅[]⟨⟩
       (λ c → ⟦ Standard-Semantics chc c ⟧₁ c)
     -- First compiler proof composition:
@@ -289,7 +289,7 @@ module VLChoiceₙ where
     ≐˘[ c ]⟨ Eq.cong (λ x → ⟦ x ⟧₂ c) (map-preserves (compile t) chc (fnoc t c)) ⟩
       (λ c → ⟦ Standard-Semantics (map (compile t) chc) (fnoc t c) ⟧₂ c)
     ≅[]⟨⟩
-      Semantics V F₁ (fnoc t) Γ₂ (map (compile t) chc)
+      Semantics V (fnoc t) Γ₂ (map (compile t) chc)
     ≅[]-∎
     where module I = IVSet V A
           open I using (_≅[_][_]_; _⊆[_]_)
@@ -324,8 +324,8 @@ module VLChoiceₙ where
               (λ c → ⟦ Standard-Semantics chc c ⟧₁ c) (fnoc t i)
             ∎
 
-  cong-compiler : ∀ V F → ConstructFunctor (Construct V F)
-  cong-compiler _ _ = record
+  cong-compiler : ∀ V → ConstructFunctor (Construct V)
+  cong-compiler _ = record
     { map = map
     ; preserves = map-compile-preserves
     }

--- a/src/Framework/V2/Constructs/GrulerArtifacts.agda
+++ b/src/Framework/V2/Constructs/GrulerArtifacts.agda
@@ -19,29 +19,29 @@ record ParallelComposition {ℓ} (A : Set ℓ) : Set ℓ where
 
 module VLLeaf where
   Syntax : ℂ
-  Syntax _ _ A = Leaf A
+  Syntax _ = Leaf
 
   make-leaf :
-    ∀ {F : 𝔽} {E : 𝔼} → F ⊢ Syntax ∈ₛ E
+    ∀ {E : 𝔼} → Syntax ∈ₛ E
     → {A : 𝔸} → A
     → E A
   make-leaf mkLeaf a = cons mkLeaf (leaf a)
 
-  elim-leaf : ∀ {V} (F : 𝔽) → F ⊢ Syntax ∈ₛ V → ∀ {A} → Leaf A → V A
-  elim-leaf _ leaf∈V l = cons leaf∈V l
+  elim-leaf : ∀ {V} → Syntax ∈ₛ V → ∀ {A} → Leaf A → V A
+  elim-leaf leaf∈V l = cons leaf∈V l
 
-  Semantics : ∀ {V F S} → F ⊢ Syntax ∈ₛ V → ℂ-Semantics V F S Syntax
-  Semantics {F = F} leaf∈V _ _ l _ = elim-leaf F leaf∈V l
+  Semantics : ∀ {V S} → Syntax ∈ₛ V → ℂ-Semantics V S Syntax
+  Semantics leaf∈V _ _ l _ = elim-leaf leaf∈V l
 
-  Construct : ∀ (V : 𝕍) (F : 𝔽) (S : 𝕊)
-    → F ⊢ Syntax ∈ₛ V
-    → VariabilityConstruct V F S
-  Construct V F S mkLeaf = record
+  Construct : ∀ (V : 𝕍) (S : 𝕊)
+    → Syntax ∈ₛ V
+    → VariabilityConstruct V S
+  Construct V S mkLeaf = record
     { Construct = Syntax
-    ; construct-semantics = Semantics {V} {F} {S} mkLeaf
+    ; construct-semantics = Semantics {V} {S} mkLeaf
     }
 
-  Leaf∈ₛGrulerVariant : ∀ {F} → F ⊢ Syntax ∈ₛ GrulerVariant
+  Leaf∈ₛGrulerVariant : Syntax ∈ₛ GrulerVariant
   cons Leaf∈ₛGrulerVariant (leaf a) = asset a
   snoc Leaf∈ₛGrulerVariant (asset a) = just (leaf a)
   snoc Leaf∈ₛGrulerVariant (_ ∥ _) = nothing
@@ -49,20 +49,20 @@ module VLLeaf where
 
 module VLParallelComposition where
   Syntax : ℂ
-  Syntax _ E A = ParallelComposition (E A)
+  Syntax E A = ParallelComposition (E A)
 
-  Semantics : ∀ {V : 𝕍} {F : 𝔽} {S : 𝕊} → F ⊢ Syntax ∈ₛ V → ℂ-Semantics V F S Syntax
+  Semantics : ∀ {V : 𝕍} {S : 𝕊} → Syntax ∈ₛ V → ℂ-Semantics V S Syntax
   Semantics leaf∈V _ (syn E with-sem ⟦_⟧) (l ∥ r) c = cons leaf∈V (⟦ l ⟧ c ∥ ⟦ r ⟧ c)
 
-  Construct : ∀ (V : 𝕍) (F : 𝔽) (S : 𝕊)
-    → F ⊢ Syntax ∈ₛ V
-    → VariabilityConstruct V F S
-  Construct V F S mkPC = record
+  Construct : ∀ (V : 𝕍) (S : 𝕊)
+    → Syntax ∈ₛ V
+    → VariabilityConstruct V S
+  Construct V S mkPC = record
     { Construct = Syntax
-    ; construct-semantics = Semantics {V} {F} {S} mkPC
+    ; construct-semantics = Semantics {V} {S} mkPC
     }
 
-  ParallelComposition∈ₛGrulerVariant : ∀ {F} → F ⊢ Syntax ∈ₛ GrulerVariant
+  ParallelComposition∈ₛGrulerVariant : Syntax ∈ₛ GrulerVariant
   cons ParallelComposition∈ₛGrulerVariant (l ∥ r) = l ∥ r
   snoc ParallelComposition∈ₛGrulerVariant (asset a) = nothing
   snoc ParallelComposition∈ₛGrulerVariant (l ∥ r) = just (l ∥ r)

--- a/src/Framework/V2/Constructs/NestedChoice.agda
+++ b/src/Framework/V2/Constructs/NestedChoice.agda
@@ -2,7 +2,7 @@
 
 open import Framework.V2.Definitions
 
-module Framework.V2.Constructs.NestedChoice (F : 𝔽) where
+module Framework.V2.Constructs.NestedChoice (F : Set) where
 
 open import Data.String using (String)
 open import Size using (Size; ↑_)

--- a/src/Framework/V2/Definitions.agda
+++ b/src/Framework/V2/Definitions.agda
@@ -9,6 +9,24 @@ open import Relation.Nullary.Negation using (¬_)
 -- open import Level using (suc; _⊔_)
 
 {-
+A variability language is a set of expressions, where each expressions is composed from a range of constructors.
+Thus, each language is in fact a set of constructors that when composed, form a set of expressions.
+
+A constructor for variability languages depicts either
+- data (including nodes with purely hierarchical information)
+- a variational construct
+
+Data depicts atomic building blocks (e.g., AST nodes) from a particular domain A.
+
+Variational constructs embody decision-making.
+That means, they ask some kind of question Q, which when answered, yields
+another sub-expression.
+The questions of different constructs vary within the same language or expression.
+For example, an expression could have a n-ary choice and an option in it.
+
+
+-}
+{-
 Some Atomic Data.
 We have no assumptions on that data so its just a type.
 -}
@@ -35,8 +53,8 @@ language's expressiveness more deeply.
 -}
 -- 𝔽 : ∀ {ℓ} → Set (suc ℓ)
 -- 𝔽 {ℓ} = Set ℓ
-𝔽 : Set₁
-𝔽 = Set
+-- 𝔽 : Set₁
+-- 𝔽 = Set
 
 {-
 Feature Selection Language.
@@ -49,10 +67,10 @@ For example, a binary choice language may use `F → Bool` as the feature
 selections language.
 -}
 𝕊 : Set₁
-𝕊 = 𝔽 → Set
+𝕊 = Set
 
-ConfigEvaluator : 𝔽 → 𝕊 → Set → Set
-ConfigEvaluator F S Sel = (S F → F → Sel)
+ConfigEvaluator : Set → 𝕊 → Set → Set
+ConfigEvaluator F S Sel = S → F → Sel
 
 {-
 The set of expressions of a variability language.
@@ -79,89 +97,89 @@ for variability annotations 𝔽.
 -- ℂ : ∀ {ℓ} → Set (suc ℓ)
 -- ℂ {ℓ} = 𝔼 {ℓ} → 𝔸 {ℓ} → Set ℓ
 ℂ : Set₁
-ℂ = 𝔽 → 𝔼 → 𝔸 → Set
+ℂ = 𝔼 → 𝔸 → Set
 
 {-
 Semantics of variability languages.
 The semantics of a set of expressions `E : 𝔼` is a function
 that configures a term `e : E A` to a variant `v : V A`
 -}
-𝔼-Semantics : 𝕍 → 𝔽 → 𝕊 → 𝔼 → Set₁
-𝔼-Semantics V F S E =
+𝔼-Semantics : 𝕍 → 𝕊 → 𝔼 → Set₁
+𝔼-Semantics V S E =
   ∀ {A : 𝔸}
   → E A
-  → S F
+  → S
   → V A
 
 -- A variability language consists of syntax and semantics (syntax is a keyword in Agda)
-record VariabilityLanguage (V : 𝕍) (F : 𝔽) (S : 𝕊) : Set₁ where
+record VariabilityLanguage (V : 𝕍) (S : 𝕊) : Set₁ where
   constructor syn_with-sem_
   field
     Expression : 𝔼
-    Semantics  : 𝔼-Semantics V F S Expression
+    Semantics  : 𝔼-Semantics V S Expression
 open VariabilityLanguage public
 
 -- Semantics of constructors
-ℂ-Semantics : 𝕍 → 𝔽 → 𝕊 → ℂ → Set₁
-ℂ-Semantics V F S C =
-  ∀ {Fγ : 𝔽} {Sγ : 𝕊}
-  → (Sγ Fγ → S F) -- a function that lets us apply language configurations to constructs
+ℂ-Semantics : 𝕍 → 𝕊 → ℂ → Set₁
+ℂ-Semantics V S C =
+  ∀ {Sγ : 𝕊}
+  → (Sγ → S ) -- a function that lets us apply language configurations to constructs
   → {A : 𝔸} -- the domain in which we embed variability
-  → (Γ : VariabilityLanguage V Fγ Sγ) -- The underlying language
-  → C F (Expression Γ) A -- the construct to compile
-  → Sγ Fγ -- a configuration for underlying subexpressions
+  → (Γ : VariabilityLanguage V Sγ) -- The underlying language
+  → C (Expression Γ) A -- the construct to compile
+  → Sγ -- a configuration for underlying subexpressions
   → V A
 
-record VariabilityConstruct (V : 𝕍) (F : 𝔽) (S : 𝕊) : Set₁ where
+record VariabilityConstruct (V : 𝕍)  (S : 𝕊) : Set₁ where
   constructor con_with-sem_
   field
     -- how to create a constructor for a given language
     Construct : ℂ
     -- how to resolve a constructor for a given language
-    construct-semantics : ℂ-Semantics V F S Construct
+    construct-semantics : ℂ-Semantics V S Construct
   _⊢⟦_⟧ = construct-semantics {Sγ = S} id
 
 -- Syntactic Containment
 -- TODO: Is there any point in allowing a specialization of F here?
 --       It lets us say "Construct x is in language y but only for the annotation language ℕ".
 --       Is there ever a use case though, in which a language must be fixed to a particular annotation language?
-record _⊢_∈ₛ_ (F : 𝔽) (C : ℂ) (E : 𝔼) : Set₁ where
+record _∈ₛ_ (C : ℂ) (E : 𝔼) : Set₁ where
   field
     -- from a construct, an expression can be created
-    cons : ∀ {A} → C F E A → E A
+    cons : ∀ {A} → C E A → E A
     -- an expression might be the construct C
-    snoc : ∀ {A} →   E A → Maybe (C F E A)
+    snoc : ∀ {A} →   E A → Maybe (C E A)
     -- An expression of a construct must preserve all information of that construct.
     -- There might be more syntactic information though because of which we do not require
     -- the dual equality cons ∘ snoc
     id-l : ∀ {A} → snoc {A} ∘ cons {A} ≗ just
-open _⊢_∈ₛ_ public
+open _∈ₛ_ public
 
-_⊢_∉ₛ_ : 𝔽 → ℂ → 𝔼 → Set₁
-F ⊢ C ∉ₛ E = ¬ (F ⊢ C ∈ₛ E)
+_∉ₛ_ : ℂ → 𝔼 → Set₁
+C ∉ₛ E = ¬ (C ∈ₛ E)
 
-_⊢_⊆ₛ_ : 𝔽 → 𝔼 → 𝔼 → Set₁
-F ⊢ E₁ ⊆ₛ E₂ = ∀ (C : ℂ) → F ⊢ C ∈ₛ E₁ → F ⊢ C ∈ₛ E₂
+_⊆ₛ_ : 𝔼 → 𝔼 → Set₁
+E₁ ⊆ₛ E₂ = ∀ (C : ℂ) → C ∈ₛ E₁ → C ∈ₛ E₂
 
-_⊢_≅ₛ_ : 𝔽 → 𝔼 → 𝔼 → Set₁
-F ⊢ E₁ ≅ₛ E₂ = F ⊢ E₁ ⊆ₛ E₂ × F ⊢ E₂ ⊆ₛ E₁
+_≅ₛ_ : 𝔼 → 𝔼 → Set₁
+E₁ ≅ₛ E₂ = E₁ ⊆ₛ E₂ × E₂ ⊆ₛ E₁
 
 -- Semantic Containment
-record _⟦∈⟧_ {V F S} (C : VariabilityConstruct V F S) (Γ : VariabilityLanguage V F S) : Set₁ where
+record _⟦∈⟧_ {V S} (C : VariabilityConstruct V S) (Γ : VariabilityLanguage V S) : Set₁ where
   open VariabilityConstruct C
   private ⟦_⟧ = Semantics Γ
   field
-    make : F ⊢ Construct ∈ₛ Expression Γ
+    make : Construct ∈ₛ Expression Γ
     preservation : ∀ {A : 𝔸}
-      → (c : Construct F (Expression Γ) A)
+      → (c : Construct (Expression Γ) A)
       → ⟦ cons make c ⟧ ≗ construct-semantics id Γ c
 open _⟦∈⟧_ public
 
-_⟦∉⟧_ : ∀ {V F S} → VariabilityConstruct V F S → VariabilityLanguage V F S → Set₁
+_⟦∉⟧_ : ∀ {V S} → VariabilityConstruct V S → VariabilityLanguage V S → Set₁
 C ⟦∉⟧ E = ¬ (C ⟦∈⟧ E)
 
-_⟦⊆⟧_ :  ∀ {V F S} → VariabilityLanguage V F S → VariabilityLanguage V F S → Set₁
-_⟦⊆⟧_ {V} {F} {S} E₁ E₂ = ∀ (C : VariabilityConstruct V F S) → C ⟦∈⟧ E₁ → C ⟦∈⟧ E₂
+_⟦⊆⟧_ :  ∀ {V S} → VariabilityLanguage V S → VariabilityLanguage V S → Set₁
+_⟦⊆⟧_ {V} {S} E₁ E₂ = ∀ (C : VariabilityConstruct V S) → C ⟦∈⟧ E₁ → C ⟦∈⟧ E₂
 
-_⟦≅⟧_ : ∀ {V F S} → VariabilityLanguage V F S → VariabilityLanguage V F S → Set₁
+_⟦≅⟧_ : ∀ {V S} → VariabilityLanguage V S → VariabilityLanguage V S → Set₁
 E₁ ⟦≅⟧ E₂ = E₁ ⟦⊆⟧ E₂ × E₂ ⟦⊆⟧ E₁

--- a/src/Framework/V2/Lang/2ADT.agda
+++ b/src/Framework/V2/Lang/2ADT.agda
@@ -2,7 +2,7 @@
 
 open import Framework.V2.Definitions
 -- TODO: Generalize level of F
-module Framework.V2.Lang.2ADT (F : 𝔽) where
+module Framework.V2.Lang.2ADT (F : Set) where
 
 open import Data.Bool using (Bool)
 open import Function using (id)
@@ -15,14 +15,14 @@ open import Framework.V2.Variants using (GrulerVariant)
 
 private
   Choice₂ = VLChoice₂.Syntax
-  Config₂ = Choice₂.Config
+  Config₂ = Choice₂.Config F
 
 2ADT : Size → 𝔼
 2ADT i A = NestedChoice i (Leaf A)
 
 mutual
-  2ADTVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant F Config₂
+  2ADTVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant Config₂
   2ADTVL {i} = syn 2ADT i with-sem semantics
 
-  semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant F Config₂ (2ADT i)
-  semantics e c = VLLeaf.elim-leaf F VLLeaf.Leaf∈ₛGrulerVariant (⟦ e ⟧ c)
+  semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant Config₂ (2ADT i)
+  semantics e c = VLLeaf.elim-leaf VLLeaf.Leaf∈ₛGrulerVariant (⟦ e ⟧ c)

--- a/src/Framework/V2/Lang/BCC.agda
+++ b/src/Framework/V2/Lang/BCC.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --sized-types #-}
 
 open import Framework.V2.Definitions
-module Framework.V2.Lang.BCC (F : 𝔽) where
+module Framework.V2.Lang.BCC (F : Set) where
 
 open import Data.Bool using (Bool)
 open import Function using (id)
@@ -10,17 +10,18 @@ open import Size using (Size; ↑_)
 open import Framework.V2.Variants
 open import Framework.V2.Constructs.Artifact using () renaming (Syntax to Artifact; Semantics to at-sem)
 import Framework.V2.Constructs.Choices as Chc
-open Chc.VLChoice₂ using () renaming (Syntax to Choice₂; Semantics to chc-sem)
+open Chc.Choice₂ using (Config)
+open Chc.VLChoice₂ F using () renaming (Syntax to Choice₂; Semantics to chc-sem)
 
 data BCC : Size → 𝔼 where
-   atom : ∀ {i A} → Artifact A (BCC i) A → BCC (↑ i) A
-   chc  : ∀ {i A} → Choice₂  F (BCC i) A → BCC (↑ i) A
+   atom : ∀ {i A} → Artifact (BCC i) A → BCC (↑ i) A
+   chc  : ∀ {i A} → Choice₂  (BCC i) A → BCC (↑ i) A
 
-module _ (V : 𝕍) (mkArtifact : F ⊢ Artifact ∈ₛ V) where
+module _ (V : 𝕍) (mkArtifact : Artifact ∈ₛ V) where
   mutual
-    BCCL : ∀ {i : Size} → VariabilityLanguage V F Bool
+    BCCL : ∀ {i : Size} → VariabilityLanguage V (Config F)
     BCCL {i} = syn BCC i with-sem ⟦_⟧
 
-    ⟦_⟧ : ∀ {i : Size} → 𝔼-Semantics V F Bool (BCC i)
-    ⟦ atom x ⟧ = at-sem F Bool mkArtifact id BCCL x
-    ⟦ chc  x ⟧ = chc-sem V F id BCCL x
+    ⟦_⟧ : ∀ {i : Size} → 𝔼-Semantics V (Config F) (BCC i)
+    ⟦ atom x ⟧ = at-sem (Config F) mkArtifact id BCCL x
+    ⟦ chc  x ⟧ = chc-sem V id BCCL x

--- a/src/Framework/V2/Lang/CCC.agda
+++ b/src/Framework/V2/Lang/CCC.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --sized-types #-}
 
 open import Framework.V2.Definitions
-module Framework.V2.Lang.CCC (F : 𝔽) where
+module Framework.V2.Lang.CCC (F : Set) where
 
 open import Data.Nat using (ℕ)
 open import Function using (id)
@@ -10,17 +10,18 @@ open import Size using (Size; ↑_; ∞)
 open import Framework.V2.Variants
 open import Framework.V2.Constructs.Artifact using () renaming (Syntax to Artifact; Semantics to at-sem)
 import Framework.V2.Constructs.Choices as Chc
-open Chc.VLChoiceₙ using () renaming (Syntax to Choiceₙ; Semantics to chc-sem)
+open Chc.Choiceₙ using (Config)
+open Chc.VLChoiceₙ F using () renaming (Syntax to Choiceₙ; Semantics to chc-sem)
 
 data CCC : Size → 𝔼 where
-   atom : ∀ {i A} → Artifact A (CCC i) A → CCC (↑ i) A
-   chc  : ∀ {i A} → Choiceₙ  F (CCC i) A → CCC (↑ i) A
+   atom : ∀ {i A} → Artifact (CCC i) A → CCC (↑ i) A
+   chc  : ∀ {i A} → Choiceₙ  (CCC i) A → CCC (↑ i) A
 
-module _ (V : 𝕍) (mkArtifact : F ⊢ Artifact ∈ₛ V) where
+module _ (V : 𝕍) (mkArtifact : Artifact ∈ₛ V) where
   mutual
-    CCCL : ∀ {i : Size} → VariabilityLanguage V F ℕ
+    CCCL : ∀ {i : Size} → VariabilityLanguage V (Config F)
     CCCL {i} = syn CCC i with-sem ⟦_⟧
 
-    ⟦_⟧ : ∀ {i : Size} → 𝔼-Semantics V F ℕ (CCC i)
-    ⟦ atom x ⟧ = at-sem F ℕ mkArtifact id CCCL x
-    ⟦ chc  x ⟧ = chc-sem V F id CCCL x
+    ⟦_⟧ : ∀ {i : Size} → 𝔼-Semantics V (Config F) (CCC i)
+    ⟦ atom x ⟧ = at-sem (Config F) mkArtifact id CCCL x
+    ⟦ chc  x ⟧ = chc-sem V id CCCL x

--- a/src/Framework/V2/Lang/Gruler.agda
+++ b/src/Framework/V2/Lang/Gruler.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --sized-types #-}
 
 open import Framework.V2.Definitions
-module Framework.V2.Lang.Gruler (F : 𝔽) where
+module Framework.V2.Lang.Gruler (F : Set) where
 
 open import Data.Bool using (Bool)
 open import Data.Maybe using (Maybe; just; nothing)
@@ -19,24 +19,24 @@ open Framework.V2.Constructs.Choices.Choice₂ using (_⟨_,_⟩) renaming (Conf
 private
   PC = VLParallelComposition.Syntax
   pc-semantics = VLParallelComposition.Semantics
-  Choice₂ = VLChoice₂.Syntax
-  choice₂-semantics = VLChoice₂.Semantics
+  Choice₂ = VLChoice₂.Syntax F
+  choice₂-semantics = VLChoice₂.Semantics F
 
 data Gruler : Size → 𝔼 where
   GAsset  : ∀ {i A} → Leaf A                           → Gruler i A
   GPComp  : ∀ {i A} → ParallelComposition (Gruler i A) → Gruler (↑ i) A
-  GChoice : ∀ {i A} → Choice₂ F (Gruler i) A      → Gruler (↑ i) A
+  GChoice : ∀ {i A} → Choice₂ (Gruler i) A      → Gruler (↑ i) A
 
-semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant F Config₂ (Gruler i)
+semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant (Config₂ F) (Gruler i)
 
-GrulerVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant F Config₂
+GrulerVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant (Config₂ F)
 GrulerVL {i} = syn Gruler i with-sem semantics
 
-semantics (GAsset a)  _ = VLLeaf.elim-leaf F VLLeaf.Leaf∈ₛGrulerVariant a
-semantics (GPComp pc)   = pc-semantics {S = Config₂} VLParallelComposition.ParallelComposition∈ₛGrulerVariant id GrulerVL pc
-semantics (GChoice chc) = choice₂-semantics GrulerVariant F id GrulerVL chc
+semantics (GAsset a)  _ = VLLeaf.elim-leaf VLLeaf.Leaf∈ₛGrulerVariant a
+semantics (GPComp pc)   = pc-semantics VLParallelComposition.ParallelComposition∈ₛGrulerVariant id GrulerVL pc
+semantics (GChoice chc) = choice₂-semantics GrulerVariant id GrulerVL chc
 
-gruler-has-leaf : ∀ {i} → F ⊢ VLLeaf.Syntax ∈ₛ Gruler i
+gruler-has-leaf : ∀ {i} → VLLeaf.Syntax ∈ₛ Gruler i
 gruler-has-leaf {i} = record
   { cons = GAsset
   ; snoc = snoc'
@@ -46,20 +46,20 @@ gruler-has-leaf {i} = record
         snoc' (GAsset A)  = just A
         snoc' _ = nothing
 
-gruler-has-choice : F ⊢ Choice₂ ∈ₛ Gruler ∞
+gruler-has-choice : Choice₂  ∈ₛ Gruler ∞
 gruler-has-choice = record
   { cons = GChoice
   ; snoc = snoc'
   ; id-l = λ _ → refl
   }
-  where snoc' : ∀ {i A} → Gruler (↑ i) A → Maybe (Choice₂ F (Gruler i) A)
+  where snoc' : ∀ {i A} → Gruler (↑ i) A → Maybe (Choice₂ (Gruler i) A)
         snoc' (GChoice chc) = just chc
         snoc' _ = nothing
 
-gruler-models-choice : VLChoice₂.Construct GrulerVariant F ⟦∈⟧ GrulerVL
+gruler-models-choice : VLChoice₂.Construct F GrulerVariant ⟦∈⟧ GrulerVL
 make gruler-models-choice = gruler-has-choice
 preservation gruler-models-choice _ _ = refl
 
 gruler-choice-preserves : ∀ {A : 𝔸} {D l r c}
-  → semantics (GChoice {A = A} (D ⟨ l , r ⟩)) c ≡ choice₂-semantics GrulerVariant F id GrulerVL (D ⟨ l , r ⟩) c
+  → semantics (GChoice {A = A} (D ⟨ l , r ⟩)) c ≡ choice₂-semantics GrulerVariant id GrulerVL (D ⟨ l , r ⟩) c
 gruler-choice-preserves = refl

--- a/src/Framework/V2/Lang/NADT.agda
+++ b/src/Framework/V2/Lang/NADT.agda
@@ -2,7 +2,7 @@
 
 open import Framework.V2.Definitions
 -- TODO: Generalize level of F
-module Framework.V2.Lang.NADT (F : 𝔽) where
+module Framework.V2.Lang.NADT (F : Set) where
 
 open import Data.Nat using (ℕ)
 open import Function using (id)
@@ -14,7 +14,7 @@ open import Framework.V2.Variants using (GrulerVariant)
 
 private
   Choice = VLChoiceₙ.Syntax
-  Config = Choiceₙ.Config
+  Config = Choiceₙ.Config F
   choice-semantics = VLChoiceₙ.Semantics
 
 data NADT : Size → 𝔼 where
@@ -22,9 +22,9 @@ data NADT : Size → 𝔼 where
   NADTChoice : ∀ {i A} → Choice F (NADT i) A → NADT (↑ i) A
 
 mutual
-  NADTVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant F Config
+  NADTVL : ∀ {i : Size} → VariabilityLanguage GrulerVariant Config
   NADTVL {i} = syn NADT i with-sem semantics
 
-  semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant F Config (NADT i)
-  semantics (NADTAsset a) _  = VLLeaf.elim-leaf F VLLeaf.Leaf∈ₛGrulerVariant a
-  semantics (NADTChoice chc) = choice-semantics GrulerVariant F id NADTVL chc
+  semantics : ∀ {i : Size} → 𝔼-Semantics GrulerVariant Config (NADT i)
+  semantics (NADTAsset a) _  = VLLeaf.elim-leaf VLLeaf.Leaf∈ₛGrulerVariant a
+  semantics (NADTChoice chc) = choice-semantics F GrulerVariant id NADTVL chc

--- a/src/Framework/V2/Translation/Construct/2Choice-to-NChoice-VL.agda
+++ b/src/Framework/V2/Translation/Construct/2Choice-to-NChoice-VL.agda
@@ -1,6 +1,6 @@
 open import Framework.V2.Definitions
 
-module Framework.V2.Translation.Construct.2Choice-to-NChoice-VL {F : 𝔽} where
+module Framework.V2.Translation.Construct.2Choice-to-NChoice-VL where
 
 open import Data.Bool using (Bool)
 open import Data.Nat using (ℕ)
@@ -22,9 +22,9 @@ open import Framework.V2.Constructs.Choices as Chc
 open Chc.Choice₂ using (_⟨_,_⟩) renaming (Config to Config₂; map to map₂)
 open Chc.Choiceₙ using () renaming (Config to Configₙ; map to mapₙ)
 
-module Translate {F : 𝔽} {V : 𝕍} {A : 𝔸}
-  (Γ₁ : VariabilityLanguage V F Config₂)
-  (Γ₂ : VariabilityLanguage V F Configₙ)
+module Translate {V : 𝕍} {Q : Set} {A : 𝔸}
+  (Γ₁ : VariabilityLanguage V (Config₂ Q))
+  (Γ₂ : VariabilityLanguage V (Configₙ Q))
   (t : LanguageCompiler Γ₁ Γ₂)
   where
   private
@@ -34,15 +34,15 @@ module Translate {F : 𝔽} {V : 𝕍} {A : 𝔸}
     ⟦_⟧₂ = Semantics  Γ₂
     open LanguageCompiler t
 
-  open VariabilityConstruct (Chc.VLChoice₂.Construct V F)
+  open VariabilityConstruct (Chc.VLChoice₂.Construct Q V)
     renaming (Construct to 2Choice; _⊢⟦_⟧ to _⊢⟦_⟧₁)
-  open VariabilityConstruct (Chc.VLChoiceₙ.Construct V F)
+  open VariabilityConstruct (Chc.VLChoiceₙ.Construct Q V)
     renaming (Construct to NChoice; _⊢⟦_⟧ to _⊢⟦_⟧₂)
 
   -- TODO: Generalize to any setoids over L₁ or L₂.
-  module 2→N-T₁ = 2→N.Translate {Q = F} (Eq.setoid (L₁ A))
+  module 2→N-T₁ = 2→N.Translate {Q} (Eq.setoid (L₁ A))
   open 2→N-T₁ using () renaming (convert to convert₁)
-  module 2→N-T = 2→N.Translate {Q = F} (Eq.setoid (L₂ A))
+  module 2→N-T = 2→N.Translate {Q} (Eq.setoid (L₂ A))
   open 2→N-T using () renaming (convert to convert₂)
 
   {-|
@@ -51,13 +51,13 @@ module Translate {F : 𝔽} {V : 𝕍} {A : 𝔸}
   Second, we convert the binary choice to an n-ary choice via convert, not changing any data.
   The order of these steps does not matter, as proven by `convert-comm` below.
   -}
-  compile-convert : 2Choice F L₁ A → NChoice F L₂ A
+  compile-convert : 2Choice L₁ A → NChoice L₂ A
   compile-convert = convert₂ ∘ map₂ compile
 
   {-|
   The same compiler as compile-convert, but the steps are executed in the other order.
   -}
-  convert-compile : 2Choice F L₁ A → NChoice F L₂ A
+  convert-compile : 2Choice L₁ A → NChoice L₂ A
   convert-compile = mapₙ compile ∘ convert₁
 
   {-|
@@ -80,7 +80,7 @@ module Translate {F : 𝔽} {V : 𝕍} {A : 𝔸}
   convert-comm _ = refl
 
   module Preservation
-    (D : F)
+    (D : Q)
     (l r : L₁ A)
     where
     open 2→N-T.Preservation conf fnoc using (convert-preserves)
@@ -99,7 +99,7 @@ module Translate {F : 𝔽} {V : 𝕍} {A : 𝔸}
         Γ₁ ⊢⟦ D ⟨ l , r ⟩ ⟧₁
       ≅[]⟨⟩
         (λ c → ⟦ Choice₂.Standard-Semantics (D ⟨ l , r ⟩) c ⟧₁ c)
-      ≅[]⟨ VLChoice₂.map-compile-preserves t (D ⟨ l , r ⟩) stable ⟩
+      ≅[]⟨ VLChoice₂.map-compile-preserves Q t (D ⟨ l , r ⟩) stable ⟩
         (λ c → ⟦ Choice₂.Standard-Semantics (map₂ compile (D ⟨ l , r ⟩)) (fnoc c) ⟧₂ c)
       ≅[]⟨⟩
         (λ c → ⟦ Choice₂.Standard-Semantics (D ⟨ compile l , compile r ⟩) (fnoc c) ⟧₂ c)

--- a/src/Framework/V2/Translation/Construct/2Choice-to-NChoice.agda
+++ b/src/Framework/V2/Translation/Construct/2Choice-to-NChoice.agda
@@ -13,7 +13,6 @@ open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl)
 
 import Data.IndexedSet
 
-open import Framework.V2.Definitions using (𝔽)
 open import Framework.V2.Compiler using (ConstructCompiler)
 open import Framework.V2.Constructs.Choices as Chc
 open Chc.Choice₂ using (_⟨_,_⟩) renaming (Syntax to 2Choice; Standard-Semantics to ⟦_⟧₂; Config to Config₂)

--- a/src/Framework/V2/Translation/Construct/NestedChoice-to-2Choice.agda
+++ b/src/Framework/V2/Translation/Construct/NestedChoice-to-2Choice.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --sized-types #-}
 {-# OPTIONS --allow-unsolved-metas #-}
-module Framework.V2.Translation.Construct.NestedChoice-to-2Choice where
+module Framework.V2.Translation.Construct.NestedChoice-to-2Choice (Q : Set) where
 
 open import Data.Bool using (Bool; false; true)
 open import Data.Product using (Σ; proj₁; Σ-syntax) renaming (_,_ to _and_)
@@ -17,29 +17,25 @@ open import Framework.V2.Annotation.IndexedName using (IndexedName)
 import Framework.V2.Constructs.Choices as Chc
 open Chc.Choiceₙ using () renaming (Config to Configₙ)
 open Chc.Choice₂ using (_⟨_,_⟩) renaming (Config to Config₂)
-open Chc.VLChoice₂ using () renaming (Syntax to Choice₂; Semantics to Choice₂-sem)
+open Chc.VLChoice₂ (IndexedName Q) using () renaming (Syntax to Choice₂; Semantics to Choice₂-sem; Construct to Choice₂-Constructor)
 
 import Framework.V2.Translation.Construct.NChoice-to-2Choice as NChoice-to-2Choice
 open NChoice-to-2Choice using (NestedChoice; value; choice; evalConfig)
-module NChoice-to-2Choice-explicit Q = NChoice-to-2Choice {Q}
-open NChoice-to-2Choice-explicit using (2Config)
+open NChoice-to-2Choice {Q} using (2Config)
 
-2Choice : ℂ
-2Choice F E A = Choice₂ (IndexedName F) E A
+2Choice-sem : ∀ (V : 𝕍) → ℂ-Semantics V 2Config Choice₂
+2Choice-sem V fnoc Γ cons conf = Choice₂-sem V (proj₁ ∘ fnoc) Γ cons conf
 
-2Choice-sem : ∀ (V : 𝕍) (F : 𝔽) → ℂ-Semantics V F 2Config 2Choice
-2Choice-sem V F fnoc Γ cons conf = Choice₂-sem V (IndexedName F) (proj₁ ∘ fnoc) Γ cons conf
-
-ChoiceConstructor : ∀ (V : 𝕍) (F : 𝔽) → VariabilityConstruct V F 2Config
-ChoiceConstructor V F = con 2Choice with-sem 2Choice-sem V F
+ChoiceConstructor : ∀ (V : 𝕍) → VariabilityConstruct V 2Config
+ChoiceConstructor V = con Choice₂ with-sem 2Choice-sem V
 
 module Embed
-  {V : 𝕍} {F : 𝔽} {A : 𝔸}
-  (Γ : VariabilityLanguage V F 2Config)
-  (constr : (ChoiceConstructor V F) ⟦∈⟧ Γ)
+  {V : 𝕍} {A : 𝔸}
+  (Γ : VariabilityLanguage V 2Config)
+  (constr : ChoiceConstructor V ⟦∈⟧ Γ)
   where
 
-  open NChoice-to-2Choice.Translate {F} (Eq.setoid (Expression Γ A))
+  open NChoice-to-2Choice.Translate {Q} (Eq.setoid (Expression Γ A))
   open Data.IndexedSet (Eq.setoid (V A)) using (_≅_; ≗→≅)
 
 

--- a/src/Framework/V2/Translation/Lang/2ADT-to-NADT.agda
+++ b/src/Framework/V2/Translation/Lang/2ADT-to-NADT.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --sized-types #-}
 
 open import Framework.V2.Definitions
-module Framework.V2.Translation.Lang.2ADT-to-NADT {F : 𝔽} {A : 𝔸} where
+module Framework.V2.Translation.Lang.2ADT-to-NADT {F : Set} {A : 𝔸} where
 
 open import Data.Nat using (ℕ)
 open import Level using (0ℓ)

--- a/src/Framework/V2/V1Compat.agda
+++ b/src/Framework/V2/V1Compat.agda
@@ -13,7 +13,7 @@ private
   variable
     A : 𝔸
 
-Complete : ∀ {V F S} → VariabilityLanguage V F S → Set₁
+Complete : ∀ {V S} → VariabilityLanguage V S → Set₁
 Complete {V} (syn L with-sem ⟦_⟧) = ∀ {A n}
   → (vs : VMap V A n)
     ----------------------------------
@@ -21,91 +21,91 @@ Complete {V} (syn L with-sem ⟦_⟧) = ∀ {A n}
       (let open Data.IndexedSet (VariantSetoid V A) renaming (_≅_ to _≋_)
         in vs ≋ ⟦ e ⟧)
 
-record TranslationResult {V F S₁ S₂} (L₁ : VariabilityLanguage V F S₁) (L₂ : VariabilityLanguage V F S₂) : Set₁ where
+record TranslationResult {V S₁ S₂} (L₁ : VariabilityLanguage V S₁) (L₂ : VariabilityLanguage V S₂) : Set₁ where
   field
     expr : Expression L₂ A
-    conf : S₁ F → S₂ F
-    fnoc : S₂ F → S₁ F
+    conf : S₁ → S₂
+    fnoc : S₂ → S₁
 open TranslationResult public
 
-Translation : ∀ {V F S₁ S₂} (L₁ : VariabilityLanguage V F S₁) (L₂ : VariabilityLanguage V F S₂) → Set₁
+Translation : ∀ {V S₁ S₂} (L₁ : VariabilityLanguage V S₁) (L₂ : VariabilityLanguage V S₂) → Set₁
 Translation L₁ L₂ = ∀ {A : 𝔸} → Expression L₁ A → TranslationResult L₁ L₂
 
 open import Relation.Binary.Indexed.Heterogeneous using (IRel; IsIndexedEquivalence)
 open import Level using (0ℓ)
 
-EXPR : ∀ (V : 𝕍) (F : 𝔽) (S : 𝕊) (A : 𝔸) → VariabilityLanguage V F S → Set
-EXPR _ _ _ A L = Expression L A
+EXPR : ∀ (V : 𝕍) (S : 𝕊) (A : 𝔸) → VariabilityLanguage V S → Set
+EXPR _ _ A L = Expression L A
 -- EXPR : ∀ {V F S} (A : 𝔸) → VariabilityLanguage V F S → Set
 -- EXPR A L = Expression L A
 
 -- _⊆ᵥ_ : ∀ {V F S A} → IRel (EXPR V F S A) 0ℓ
-_⊆ᵥ_ : ∀ {V F S} {Γ₁ : VariabilityLanguage V F S} {Γ₂ : VariabilityLanguage V F S} {A}
+_⊆ᵥ_ : ∀ {V S} {Γ₁ : VariabilityLanguage V S} {Γ₂ : VariabilityLanguage V S} {A}
   → Expression Γ₁ A
   → Expression Γ₂ A
   → Set
-_⊆ᵥ_ {V} {_} {_} {L₁} {L₂} {A} e₁ e₂ = ⟦ e₁ ⟧₁ ⊆ ⟦ e₂ ⟧₂
+_⊆ᵥ_ {V} {_} {L₁} {L₂} {A} e₁ e₂ = ⟦ e₁ ⟧₁ ⊆ ⟦ e₂ ⟧₂
   where ⟦_⟧₁ = Semantics L₁
         ⟦_⟧₂ = Semantics L₂
         open Data.IndexedSet (VariantSetoid V A) using (_⊆_)
 infix 5 _⊆ᵥ_
 
 -- _≚_ : ∀ {A : 𝔸} → IRel (Expression A) 0ℓ
-_,_⊢_≚_ : ∀ {V F₁ F₂ S₁ S₂ A}
-  → (Γ₁ : VariabilityLanguage V F₁ S₁)
-  → (Γ₂ : VariabilityLanguage V F₂ S₂)
+_,_⊢_≚_ : ∀ {V S₁ S₂ A}
+  → (Γ₁ : VariabilityLanguage V S₁)
+  → (Γ₂ : VariabilityLanguage V S₂)
   → Expression Γ₁ A
   → Expression Γ₂ A
   → Set
-_,_⊢_≚_ {V} {_} {_} {_} {_} {A} L₁ L₂ e₁ e₂ = ⟦ e₁ ⟧₁ ≅ ⟦ e₂ ⟧₂
+_,_⊢_≚_ {V} {_} {_} {A} L₁ L₂ e₁ e₂ = ⟦ e₁ ⟧₁ ≅ ⟦ e₂ ⟧₂
   where ⟦_⟧₁ = Semantics L₁
         ⟦_⟧₂ = Semantics L₂
         open Data.IndexedSet (VariantSetoid V A) using (_≅_)
 infix 5 _,_⊢_≚_
 
-Conf-Preserves :  ∀ {V F S₁ S₂}
-  → (L₁ : VariabilityLanguage V F S₁)
-  → (L₂ : VariabilityLanguage V F S₂)
+Conf-Preserves :  ∀ {V S₁ S₂}
+  → (L₁ : VariabilityLanguage V S₁)
+  → (L₂ : VariabilityLanguage V S₂)
   → Expression L₁ A
   → Expression L₂ A
-  → (S₁ F → S₂ F)
+  → (S₁ → S₂)
   → Set
-Conf-Preserves {F = F} {S₁ = S₁} L₁ L₂ e₁ e₂ conf =
-  ∀ (c₁ : S₁ F) → ⟦ e₁ ⟧₁ c₁ ≡ ⟦ e₂ ⟧₂ (conf c₁)
+Conf-Preserves {S₁ = S₁} L₁ L₂ e₁ e₂ conf =
+  ∀ (c₁ : S₁) → ⟦ e₁ ⟧₁ c₁ ≡ ⟦ e₂ ⟧₂ (conf c₁)
   where ⟦_⟧₁ = Semantics L₁
         ⟦_⟧₂ = Semantics L₂
 
-Fnoc-Preserves :  ∀ {V F S₁ S₂}
-  → (L₁ : VariabilityLanguage V F S₁)
-  → (L₂ : VariabilityLanguage V F S₂)
+Fnoc-Preserves :  ∀ {V S₁ S₂}
+  → (L₁ : VariabilityLanguage V S₁)
+  → (L₂ : VariabilityLanguage V S₂)
   → Expression L₁ A
   → Expression L₂ A
-  → (S₂ F → S₁ F)
+  → (S₂ → S₁)
   → Set
-Fnoc-Preserves {F = F} {S₂ = S₂} L₁ L₂ e₁ e₂ fnoc =
-  ∀ (c₂ : S₂ F) → ⟦ e₂ ⟧₂ c₂ ≡ ⟦ e₁ ⟧₁ (fnoc c₂)
+Fnoc-Preserves  {S₂ = S₂} L₁ L₂ e₁ e₂ fnoc =
+  ∀ (c₂ : S₂) → ⟦ e₂ ⟧₂ c₂ ≡ ⟦ e₁ ⟧₁ (fnoc c₂)
   where ⟦_⟧₁ = Semantics L₁
         ⟦_⟧₂ = Semantics L₂
 
-_⊆ₛ-via_ : ∀ {V F S₁ S₂} {L₁ : VariabilityLanguage V F S₁} {L₂ : VariabilityLanguage V F S₂}
+_⊆ₛ-via_ : ∀ {V S₁ S₂} {L₁ : VariabilityLanguage V S₁} {L₂ : VariabilityLanguage V S₂}
   → (e : Expression L₁ A)
   → Translation L₁ L₂
   → Set
 _⊆ₛ-via_ {L₁ = L₁} {L₂ = L₂} e₁ translate = Conf-Preserves L₁ L₂ e₁ (expr (translate e₁)) (conf (translate e₁))
 
-_⊇-via_ : ∀ {V F S₁ S₂} {L₁ : VariabilityLanguage V F S₁} {L₂ : VariabilityLanguage V F S₂}
+_⊇-via_ : ∀ {V S₁ S₂} {L₁ : VariabilityLanguage V S₁} {L₂ : VariabilityLanguage V S₂}
   → (e : Expression L₁ A)
   → Translation L₁ L₂
   → Set
 _⊇-via_ {L₁ = L₁} {L₂ = L₂} e₁ translate = Fnoc-Preserves L₁ L₂ e₁ (expr (translate e₁)) (fnoc (translate e₁))
 
-_≚-via_ : ∀ {V F S₁ S₂} {L₁ : VariabilityLanguage V F S₁} {L₂ : VariabilityLanguage V F S₂}
+_≚-via_ : ∀ {V S₁ S₂} {L₁ : VariabilityLanguage V S₁} {L₂ : VariabilityLanguage V S₂}
   → (e : Expression L₁ A)
   → Translation L₁ L₂
   → Set
 e ≚-via t = e ⊆ₛ-via t × e ⊇-via t
 
-_is-variant-preserving :  ∀ {V F S₁ S₂} {L₁ : VariabilityLanguage V F S₁} {L₂ : VariabilityLanguage V F S₂} → Translation L₁ L₂ → Set₁
+_is-variant-preserving :  ∀ {V S₁ S₂} {L₁ : VariabilityLanguage V S₁} {L₂ : VariabilityLanguage V S₂} → Translation L₁ L₂ → Set₁
 _is-variant-preserving {L₁ = L₁} t = ∀ {A : 𝔸} → (e₁ : Expression L₁ A) → e₁ ≚-via t
 
 -- -- any language with artifacts and choices is complete


### PR DESCRIPTION
Initially, an annotation (or feature) language `F` was a defining factor of a variability language. The motivation was to be able to reason on the impact of `F` on the expressiveness of the language in the future. However, as of now, there is no use case for abstracting over the annotation language, hence inducing lots of boilerplate code without benefit. Moreover, a single variability language might be composed of different constructor, each with a different annotation language.

Now, all information on annotation languages is stored within respective constructors, and the required configurations.