### PR TITLE
Variation Trees

### DIFF
--- a/src/Vatras/Data/Prop.agda
+++ b/src/Vatras/Data/Prop.agda
@@ -32,13 +32,3 @@ eval (var p) c = c p
 eval (¬ p)   c = Bool.not (eval p c)
 eval (p ∧ q) c = (eval p c) Bool.∧ (eval q c)
 
-module Properties where
-  open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl)
-  open import Data.Product using (Σ)
-  open Eq.≡-Reasoning
-
-  Satisfying : ∀ {F} → Prop F → Assignment F → Set
-  Satisfying p a = eval p a ≡ Bool.true
-
-  Satisfiable : ∀ {F} → Prop F → Set
-  Satisfiable {F} p = Σ (Assignment F) (Satisfying p)

--- a/src/Vatras/Data/Prop.agda
+++ b/src/Vatras/Data/Prop.agda
@@ -9,7 +9,6 @@ data Prop (F : Set) : Set where
   ¬_    : Prop F → Prop F
   _∧_   : Prop F → Prop F → Prop F
 
-infix 24 var
 infix 23 ¬_
 infix 22 _∧_
 

--- a/src/Vatras/Data/Prop.agda
+++ b/src/Vatras/Data/Prop.agda
@@ -1,6 +1,6 @@
 module Vatras.Data.Prop where
 
-open import Data.Bool as Bool using (Bool; if_then_else_)
+open import Data.Bool as Bool using (Bool)
 
 data Prop (F : Set) : Set where
   true  : Prop F

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -4,7 +4,7 @@ import Data.Bool as Bool
 open import Data.Bool.Properties using (∧-comm; ∧-zeroʳ)
 open import Data.Empty using (⊥)
 open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
-open import Data.Sum as Sum using (_⊎_) renaming (inj₁ to left; inj₂ to right)
+open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 
 open import Relation.Nullary.Negation renaming (¬_ to never)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong; sym; trans)
@@ -57,12 +57,12 @@ Const' : Prop F → Set
 Const' p = ∃[ b ] (∀ a → eval p a ≡ b)
 
 Const→Const' : ∀ {p} → Const p → Const' p
-Const→Const' (left  taut ) = Bool.true  , taut
-Const→Const' (right contr) = Bool.false , contr
+Const→Const' (inj₁ taut ) = Bool.true  , taut
+Const→Const' (inj₂ contr) = Bool.false , contr
 
 Const'→Const : ∀ {p} → Const' p → Const p
-Const'→Const (Bool.true  , taut ) = left  taut
-Const'→Const (Bool.false , contr) = right contr
+Const'→Const (Bool.true  , taut ) = inj₁ taut
+Const'→Const (Bool.false , contr) = inj₂ contr
 
 Nonconst : Prop F → Set
 Nonconst p = Satisfiable p × Falsifiable p
@@ -71,8 +71,8 @@ Nonconst' : Prop F → Set
 Nonconst' p = never (Const p)
 
 Nonconst→Nonconst' : ∀ {p} → Nonconst p → Nonconst' p
-Nonconst→Nonconst' {p} (_ , (a , a-makes-false)) (left taut)   = NonContradiction' p a (taut a) a-makes-false
-Nonconst→Nonconst' {p} ((a , a-makes-true) , _)  (right contr) = NonContradiction' p a a-makes-true (contr a)
+Nonconst→Nonconst' {p} (_ , (a , a-makes-false)) (inj₁ taut ) = NonContradiction' p a (taut a) a-makes-false
+Nonconst→Nonconst' {p} ((a , a-makes-true) , _)  (inj₂ contr) = NonContradiction' p a a-makes-true (contr a)
 
 sat-∧ˡ : ∀ p q
   → Tautology p

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -4,7 +4,7 @@ import Data.Bool as Bool
 open import Data.Bool.Properties using (∧-comm; ∧-zeroˡ; ∧-zeroʳ)
 open import Data.Empty using (⊥)
 open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
-open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 
 open import Relation.Nullary.Negation renaming (¬_ to negate)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong; sym; trans)

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -30,7 +30,7 @@ NonContradiction' :
   → eval p a ≡ Bool.true
   → eval p a ≡ Bool.false
   → ⊥
-NonContradiction' _ _ t f = true≢false (trans (sym f) t) refl
+NonContradiction' _ _ = true≢false
 
 Satisfying : Prop F → Assignment F → Set
 Satisfying p a = eval p a ≡ Bool.true

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -1,7 +1,7 @@
 module Vatras.Data.Prop.Properties {F : Set} where
 
 import Data.Bool as Bool
-open import Data.Bool.Properties using (∧-comm; ∧-zeroʳ)
+open import Data.Bool.Properties using (∧-comm; ∧-zeroˡ; ∧-zeroʳ)
 open import Data.Empty using (⊥)
 open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
@@ -95,10 +95,19 @@ sat-∧ʳ p q taut-q (a , sat) = a , (
   eval p a Bool.∧ Bool.true ≡⟨ cong (Bool._∧ Bool.true) sat ⟩
   Bool.true                 ∎)
 
-fal-∧ : ∀ p q
+fal-∧ˡ : ∀ p q
+  → Falsifiable p
+  → Falsifiable (p ∧ q)
+fal-∧ˡ p q (a , unsat) = a , (
+  eval (p ∧ q) a             ≡⟨⟩
+  eval p a   Bool.∧ eval q a ≡⟨ cong (Bool._∧ eval q a) unsat ⟩
+  Bool.false Bool.∧ eval q a ≡⟨ ∧-zeroˡ (eval q a) ⟩
+  Bool.false                 ∎)
+
+fal-∧ʳ : ∀ p q
   → Falsifiable q
   → Falsifiable (p ∧ q)
-fal-∧ p q (a , unsat) = a , (
+fal-∧ʳ p q (a , unsat) = a , (
   eval (p ∧ q) a             ≡⟨⟩
   eval p a Bool.∧ eval q a   ≡⟨ cong (eval p a Bool.∧_) unsat ⟩
   eval p a Bool.∧ Bool.false ≡⟨ ∧-zeroʳ (eval p a) ⟩

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -6,7 +6,7 @@ open import Data.Empty using (⊥)
 open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 
-open import Relation.Nullary.Negation renaming (¬_ to never)
+open import Relation.Nullary.Negation renaming (¬_ to negate)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong; sym; trans)
 open Eq.≡-Reasoning
 
@@ -68,7 +68,7 @@ Nonconst : Prop F → Set
 Nonconst p = Satisfiable p × Falsifiable p
 
 Nonconst' : Prop F → Set
-Nonconst' p = never (Const p)
+Nonconst' p = negate (Const p)
 
 Nonconst→Nonconst' : ∀ {p} → Nonconst p → Nonconst' p
 Nonconst→Nonconst' {p} (_ , (a , a-makes-false)) (inj₁ taut ) = NonContradiction' p a (taut a) a-makes-false

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -1,7 +1,7 @@
 module Vatras.Data.Prop.Properties {F : Set} where
 
-open import Data.Bool as Bool using ()
-open import Data.Bool.Properties using (∧-comm; ∧-zeroˡ; ∧-zeroʳ)
+import Data.Bool as Bool
+open import Data.Bool.Properties using (∧-comm; ∧-zeroʳ)
 open import Data.Empty using (⊥)
 open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
 open import Data.Sum as Sum using (_⊎_) renaming (inj₁ to left; inj₂ to right)
@@ -9,8 +9,6 @@ open import Data.Sum as Sum using (_⊎_) renaming (inj₁ to left; inj₂ to ri
 open import Relation.Nullary.Negation renaming (¬_ to never)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong; sym; trans)
 open Eq.≡-Reasoning
-
-open import Function using (_∘_)
 
 open import Vatras.Data.Prop
 open import Vatras.Util.AuxProofs using (true≢false)

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -1,0 +1,137 @@
+module Vatras.Data.Prop.Properties {F : Set} where
+
+open import Data.Bool as Bool using ()
+open import Data.Bool.Properties using (∧-comm; ∧-zeroˡ; ∧-zeroʳ)
+open import Data.Empty using (⊥)
+open import Data.Product as Product using (Σ; _×_; ∃-syntax; _,_)
+open import Data.Sum as Sum using (_⊎_) renaming (inj₁ to left; inj₂ to right)
+
+open import Relation.Nullary.Negation renaming (¬_ to never)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong; sym; trans)
+open Eq.≡-Reasoning
+
+open import Function using (_∘_)
+
+open import Vatras.Data.Prop
+
+all-true : Assignment F
+all-true _ = Bool.true
+
+all-false : Assignment F
+all-false _ = Bool.false
+
+module _ where
+  false≢true : Bool.false ≡ Bool.true → ⊥
+  false≢true ()
+
+NonContradiction :
+  ∀ {b} {p : Prop F} (a : Assignment F)
+  → eval    p  a ≡ b
+  → eval (¬ p) a ≡ Bool.not b
+NonContradiction _ eq = cong Bool.not eq
+
+NonContradiction' :
+  ∀ (p : Prop F) (a : Assignment F)
+  → eval p a ≡ Bool.true
+  → eval p a ≡ Bool.false
+  → ⊥
+NonContradiction' _ _ t f = false≢true (trans (sym f) t)
+
+Satisfying : Prop F → Assignment F → Set
+Satisfying p a = eval p a ≡ Bool.true
+
+Unsatisfying : Prop F → Assignment F → Set
+Unsatisfying p a = eval p a ≡ Bool.false
+
+Satisfiable : Prop F → Set
+Satisfiable p = Σ (Assignment F) (Satisfying p)
+
+Falsifiable : Prop F → Set
+Falsifiable p = Σ (Assignment F) (Unsatisfying p)
+
+Tautology : Prop F → Set
+Tautology p = ∀ a → Satisfying p a
+
+Contradiction : Prop F → Set
+Contradiction p = ∀ a → Unsatisfying p a
+
+Const : Prop F → Set
+Const p = Tautology p ⊎ Contradiction p
+
+Const' : Prop F → Set
+Const' p = ∃[ b ] (∀ a → eval p a ≡ b)
+
+Const→Const' : ∀ {p} → Const p → Const' p
+Const→Const' (left  taut ) = Bool.true  , taut
+Const→Const' (right contr) = Bool.false , contr
+
+Const'→Const : ∀ {p} → Const' p → Const p
+Const'→Const (Bool.true  , taut ) = left  taut
+Const'→Const (Bool.false , contr) = right contr
+
+Nonconst : Prop F → Set
+Nonconst p = Satisfiable p × Falsifiable p
+
+Nonconst' : Prop F → Set
+Nonconst' p = never (Const p)
+
+Nonconst→Nonconst' : ∀ {p} → Nonconst p → Nonconst' p
+Nonconst→Nonconst' {p} (_ , (a , a-makes-false)) (left taut)   = NonContradiction' p a (taut a) a-makes-false
+Nonconst→Nonconst' {p} ((a , a-makes-true) , _)  (right contr) = NonContradiction' p a a-makes-true (contr a)
+
+sat-∧ˡ : ∀ p q
+  → Tautology p
+  → Satisfiable q
+  → Satisfiable (p ∧ q)
+sat-∧ˡ p q taut-p (a , sat) = a , (
+  eval (p ∧ q) a            ≡⟨⟩
+  eval p a  Bool.∧ eval q a ≡⟨ cong (Bool._∧ eval q a) (taut-p a) ⟩
+  Bool.true Bool.∧ eval q a ≡⟨⟩
+  eval q a                  ≡⟨ sat ⟩
+  Bool.true                 ∎)
+
+sat-∧ʳ : ∀ p q
+  → Tautology q
+  → Satisfiable p
+  → Satisfiable (p ∧ q)
+sat-∧ʳ p q taut-q (a , sat) = a , (
+  eval (p ∧ q) a            ≡⟨⟩
+  eval p a Bool.∧ eval q a  ≡⟨ cong (eval p a Bool.∧_) (taut-q a) ⟩
+  eval p a Bool.∧ Bool.true ≡⟨ cong (Bool._∧ Bool.true) sat ⟩
+  Bool.true                 ∎)
+
+fal-∧ : ∀ p q
+  → Falsifiable q
+  → Falsifiable (p ∧ q)
+fal-∧ p q (a , unsat) = a , (
+  eval (p ∧ q) a             ≡⟨⟩
+  eval p a Bool.∧ eval q a   ≡⟨ cong (eval p a Bool.∧_) unsat ⟩
+  eval p a Bool.∧ Bool.false ≡⟨ ∧-zeroʳ (eval p a) ⟩
+  Bool.false                 ∎)
+
+-- generalize?
+fal-∧-cong : ∀ p q
+  → Falsifiable (p ∧ q)
+  → Falsifiable (q ∧ p)
+fal-∧-cong p q (a , unsat) rewrite ∧-comm (eval p a) (eval q a) = a , unsat
+
+taut-∧ : ∀ p q
+  → Tautology p
+  → Tautology q
+  → Tautology (p ∧ q)
+taut-∧ p q taut-p taut-q a rewrite taut-p a | taut-q a = refl
+
+contr-∧ˡ : ∀ p q
+  → Contradiction p
+  → Contradiction (p ∧ q)
+contr-∧ˡ p q contr-p a rewrite contr-p a = refl
+
+contr-∧ʳ : ∀ p q
+  → Contradiction q
+  → Contradiction (p ∧ q)
+contr-∧ʳ p q contr-q a =
+    eval (p ∧ q) a             ≡⟨⟩
+    eval p a Bool.∧ eval q a   ≡⟨ cong (eval p a Bool.∧_) (contr-q a) ⟩
+    eval p a Bool.∧ Bool.false ≡⟨ ∧-comm (eval p a) Bool.false ⟩
+    Bool.false                 ∎
+

--- a/src/Vatras/Data/Prop/Properties.agda
+++ b/src/Vatras/Data/Prop/Properties.agda
@@ -13,16 +13,13 @@ open Eq.≡-Reasoning
 open import Function using (_∘_)
 
 open import Vatras.Data.Prop
+open import Vatras.Util.AuxProofs using (true≢false)
 
 all-true : Assignment F
 all-true _ = Bool.true
 
 all-false : Assignment F
 all-false _ = Bool.false
-
-module _ where
-  false≢true : Bool.false ≡ Bool.true → ⊥
-  false≢true ()
 
 NonContradiction :
   ∀ {b} {p : Prop F} (a : Assignment F)
@@ -35,7 +32,7 @@ NonContradiction' :
   → eval p a ≡ Bool.true
   → eval p a ≡ Bool.false
   → ⊥
-NonContradiction' _ _ t f = false≢true (trans (sym f) t)
+NonContradiction' _ _ t f = true≢false (trans (sym f) t) refl
 
 Satisfying : Prop F → Assignment F → Set
 Satisfying p a = eval p a ≡ Bool.true

--- a/src/Vatras/Framework/Annotation/IndexedDimension.agda
+++ b/src/Vatras/Framework/Annotation/IndexedDimension.agda
@@ -6,6 +6,7 @@ IndexedDimension is used for conversions from NCC to NCC with lower arity (in pa
 module Vatras.Framework.Annotation.IndexedDimension where
 
 open import Data.Fin using (Fin)
+open import Data.Nat using (ℕ)
 open import Data.Product using (_×_)
 open import Vatras.Util.Nat.AtLeast using (ℕ≥; toℕ; pred)
 open import Vatras.Framework.Definitions using (𝔽)
@@ -16,3 +17,6 @@ D with indices i ∈ ℕ, where 2 ≤ n.
 -}
 IndexedDimension : (D : 𝔽) → (n : ℕ≥ 2) → 𝔽
 IndexedDimension D n = D × Fin (toℕ (pred n))
+
+Indexed : 𝔽 → 𝔽
+Indexed F = F × ℕ

--- a/src/Vatras/Framework/Definitions.agda
+++ b/src/Vatras/Framework/Definitions.agda
@@ -65,10 +65,18 @@ and hence expressions are parameterized in the type of this atomic data.
 -- some default atoms
 module _ where
   open import Data.String using (String; _≟_)
+
+  _String≟_ : DecidableEquality String
+  _String≟_ = _≟_
+
   STRING : 𝔸
-  STRING = String and _≟_
+  STRING = String and _String≟_
 
 module _ where
   open import Data.Nat using (ℕ; _≟_)
+
+  _ℕ≟_ : DecidableEquality ℕ
+  _ℕ≟_ = _≟_
+
   NAT : 𝔸
-  NAT = ℕ and _≟_
+  NAT = ℕ and _ℕ≟_

--- a/src/Vatras/Framework/Definitions.agda
+++ b/src/Vatras/Framework/Definitions.agda
@@ -61,3 +61,14 @@ and hence expressions are parameterized in the type of this atomic data.
 -}
 𝔼 : Set₂
 𝔼 = 𝔸 → Set₁
+
+-- some default atoms
+module _ where
+  open import Data.String using (String; _≟_)
+  STRING : 𝔸
+  STRING = String and _≟_
+
+module _ where
+  open import Data.Nat using (ℕ; _≟_)
+  NAT : 𝔸
+  NAT = ℕ and _≟_

--- a/src/Vatras/Framework/Definitions.agda
+++ b/src/Vatras/Framework/Definitions.agda
@@ -66,17 +66,11 @@ and hence expressions are parameterized in the type of this atomic data.
 module _ where
   open import Data.String using (String; _≟_)
 
-  _String≟_ : DecidableEquality String
-  _String≟_ = _≟_
-
   STRING : 𝔸
-  STRING = String and _String≟_
+  STRING = String and _≟_
 
 module _ where
   open import Data.Nat using (ℕ; _≟_)
 
-  _ℕ≟_ : DecidableEquality ℕ
-  _ℕ≟_ = _≟_
-
   NAT : 𝔸
-  NAT = ℕ and _ℕ≟_
+  NAT = ℕ and _≟_

--- a/src/Vatras/Framework/Variants.agda
+++ b/src/Vatras/Framework/Variants.agda
@@ -53,6 +53,12 @@ data GrulerVariant : 𝕍 where
 rose-leaf : ∀ {A : 𝔸} → atoms A → Rose ∞ A
 rose-leaf {A} a = a -< [] >-
 
+forest-leaf : ∀ {A : 𝔸} → atoms A → Forest A
+forest-leaf a = rose-leaf a ∷ []
+
+forest-singleton : ∀ {A : 𝔸} → atoms A → Forest A → Forest A
+forest-singleton a l = a -< l >- ∷ []
+
 {-|
 Interestingly, variants are also variability languages
 (and it does not matter how variants actually look like).

--- a/src/Vatras/Lang/ADT/Merge.agda
+++ b/src/Vatras/Lang/ADT/Merge.agda
@@ -3,19 +3,18 @@ module Vatras.Lang.ADT.Merge
   (V : 𝕍)
   (_+ᵥ_ : ∀ {A} → V A → V A → V A)
   where
-open import Data.Bool using (Bool; if_then_else_; true; false)
+
+open import Data.Bool using (if_then_else_; true; false)
 open import Data.Bool.Properties using (if-float)
 open import Relation.Binary.PropositionalEquality using (refl; _≡_; _≗_)
 open Relation.Binary.PropositionalEquality.≡-Reasoning
 
-open import Vatras.Framework.Relation.Expression V
-open import Vatras.Util.AuxProofs using (if-cong; if-swap)
+open import Vatras.Util.AuxProofs using (if-cong)
 
 import Vatras.Lang.ADT
-module ADT F = Vatras.Lang.ADT F V
 
 module Named (F : 𝔽) where
-  open ADT F
+  open Vatras.Lang.ADT F V
 
   {-|
   Merges two ADTs.
@@ -98,7 +97,7 @@ module Named (F : 𝔽) where
 
 module Prop (F : 𝔽) where
   open import Vatras.Data.Prop
-  open ADT (Prop F)
+  open Vatras.Lang.ADT (Prop F) V
   open import Vatras.Lang.ADT.Prop F V
   open Named (Prop F)
 

--- a/src/Vatras/Lang/ADT/Merge.agda
+++ b/src/Vatras/Lang/ADT/Merge.agda
@@ -23,40 +23,19 @@ module Named (F : 𝔽) where
   This operations inherits all properties of the variant composition (e.g., commutativity, associativity etc).
   -}
   _⊕_ : ∀ {A} → ADT A → ADT A → ADT A
-  leaf l          ⊕ leaf r          = leaf (l +ᵥ r)
-  leaf l          ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
-  (D ⟨ dl , dr ⟩) ⊕ leaf r          = D ⟨ dl ⊕ leaf r , dr ⊕ leaf r ⟩
-  (D ⟨ dl , dr ⟩) ⊕ (E ⟨ el , er ⟩) = D ⟨ E ⟨ dl ⊕ el , dl ⊕ er ⟩ , E ⟨ dr ⊕ el , dr ⊕ er ⟩ ⟩
+  leaf l         ⊕ leaf r         = leaf (l +ᵥ r)
+  leaf l         ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
+  (D ⟨ dl , dr ⟩) ⊕ r              = D ⟨ dl ⊕ r , dr ⊕ r ⟩
 
   ⊕-spec : ∀ {A} (l r : ADT A) (c : Configuration) →
      ⟦ l ⊕ r ⟧ c ≡ ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c
-  ⊕-spec (leaf l)        (leaf r       ) c = refl
-  ⊕-spec (leaf l)        (E ⟨ el , er ⟩) c =
-    -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
-      ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
-    ≡⟨⟩
-      (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
-    ≡⟨ if-cong (c E) (⊕-spec (leaf l) el c) (⊕-spec (leaf l) er c) ⟩
-      (if c E
-       then ⟦ leaf l ⟧ c +ᵥ ⟦ el ⟧ c
-       else ⟦ leaf l ⟧ c +ᵥ ⟦ er ⟧ c)
-    ≡⟨⟩
-      (if c E
-       then l +ᵥ ⟦ el ⟧ c
-       else l +ᵥ ⟦ er ⟧ c)
-    ≡⟨ if-float (l +ᵥ_) (c E) ⟨
-      l +ᵥ (if c E then ⟦ el ⟧ c else ⟦ er ⟧ c)
-    ≡⟨⟩
-      ⟦ leaf l ⟧ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ c
-    ∎
-  ⊕-spec (D ⟨ dl , dr ⟩) (leaf r       ) c with c D
-  ... | true  = ⊕-spec dl (leaf r) c
-  ... | false = ⊕-spec dr (leaf r) c
-  ⊕-spec (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
-  ... | true  | true  = ⊕-spec dl el c
-  ... | true  | false = ⊕-spec dl er c
-  ... | false | true  = ⊕-spec dr el c
-  ... | false | false = ⊕-spec dr er c
+  ⊕-spec (leaf l) (leaf r) c = refl
+  ⊕-spec (leaf l) (E ⟨ el , er ⟩) c with c E
+  ... | true = ⊕-spec (leaf l) el c
+  ... | false = ⊕-spec (leaf l) er c
+  ⊕-spec (D ⟨ dl , dr ⟩) r c with c D
+  ... | true  = ⊕-spec dl r c
+  ... | false = ⊕-spec dr r c
 
   ---- Properties ----
   -- The merge operator inherits
@@ -75,25 +54,15 @@ module Named (F : 𝔽) where
     (∀ {A} (v w : V A) → v +ᵥ w ≡ w +ᵥ v) →
     ---------------------------------------------
     (∀ {A} (l r : ADT A) → ⟦ l ⊕ r ⟧ ≗ ⟦ r ⊕ l ⟧)
-  ⊕-comm +ᵥ-comm (leaf l       ) (leaf r       ) _ = +ᵥ-comm l r
-  ⊕-comm +ᵥ-comm (leaf l       ) (E ⟨ el , er ⟩) c =
-      ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
-    ≡⟨⟩
-      (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
-    ≡⟨ if-cong (c E) (⊕-comm +ᵥ-comm (leaf l) el c) (⊕-comm +ᵥ-comm (leaf l) er c) ⟩
-      (if c E then ⟦ el ⊕ leaf l ⟧ c else ⟦ er ⊕ leaf l ⟧ c)
-    ≡⟨⟩
-      ⟦ E ⟨ el ⊕ leaf l , er ⊕ leaf l ⟩ ⟧ c
+  ⊕-comm +ᵥ-comm l r c =
+      ⟦ l ⊕ r ⟧ c
+    ≡⟨ ⊕-spec l r c ⟩
+      ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c
+    ≡⟨ +ᵥ-comm (⟦ l ⟧ c) (⟦ r ⟧ c) ⟩
+      ⟦ r ⟧ c +ᵥ ⟦ l ⟧ c
+    ≡⟨ ⊕-spec r l c ⟨
+      ⟦ r ⊕ l ⟧ c
     ∎
-  ⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (leaf r       ) c
-    rewrite ⊕-comm +ᵥ-comm dl (leaf r) c
-          | ⊕-comm +ᵥ-comm dr (leaf r) c
-          = refl
-  ⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
-  ... | true  | true  = ⊕-comm +ᵥ-comm dl el c
-  ... | true  | false = ⊕-comm +ᵥ-comm dl er c
-  ... | false | true  = ⊕-comm +ᵥ-comm dr el c
-  ... | false | false = ⊕-comm +ᵥ-comm dr er c
 
 module Prop (F : 𝔽) where
   open import Vatras.Data.Prop
@@ -104,29 +73,9 @@ module Prop (F : 𝔽) where
   ⊕-specₚ : ∀ {A} (l r : ADT A) (c : Assignment F) →
      ⟦ l ⊕ r ⟧ₚ c ≡ ⟦ l ⟧ₚ c +ᵥ ⟦ r ⟧ₚ c
   ⊕-specₚ (leaf v) (leaf r) c = refl
-  ⊕-specₚ (leaf l) (E ⟨ el , er ⟩) c =
-    -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
-      ⟦ leaf l ⊕ (E ⟨ el , er ⟩) ⟧ₚ c
-    ≡⟨⟩
-      (if eval E c then ⟦ leaf l ⊕ el ⟧ₚ c else ⟦ leaf l ⊕ er ⟧ₚ c)
-    ≡⟨ if-cong (eval E c) (⊕-specₚ (leaf l) el c) (⊕-specₚ (leaf l) er c) ⟩
-      (if eval E c
-       then ⟦ leaf l ⟧ₚ c +ᵥ ⟦ el ⟧ₚ c
-       else ⟦ leaf l ⟧ₚ c +ᵥ ⟦ er ⟧ₚ c)
-    ≡⟨⟩
-      (if eval E c
-       then l +ᵥ ⟦ el ⟧ₚ c
-       else l +ᵥ ⟦ er ⟧ₚ c)
-    ≡⟨ if-float (l +ᵥ_) (eval E c) ⟨
-      l +ᵥ (if eval E c then ⟦ el ⟧ₚ c else ⟦ er ⟧ₚ c)
-    ≡⟨⟩
-      ⟦ leaf l ⟧ₚ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ₚ c
-    ∎
-  ⊕-specₚ (D ⟨ dl , dr ⟩) (leaf v) c with eval D c
-  ... | true  = ⊕-specₚ dl (leaf v) c
-  ... | false = ⊕-specₚ dr (leaf v) c
-  ⊕-specₚ (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with eval D c | eval E c
-  ... | true  | true  = ⊕-specₚ dl el c
-  ... | true  | false = ⊕-specₚ dl er c
-  ... | false | true  = ⊕-specₚ dr el c
-  ... | false | false = ⊕-specₚ dr er c
+  ⊕-specₚ (leaf l) (E ⟨ el , er ⟩) c with eval E c
+  ... | true  = ⊕-specₚ (leaf l) el c
+  ... | false = ⊕-specₚ (leaf l) er c
+  ⊕-specₚ (D ⟨ dl , dr ⟩) r c with eval D c
+  ... | true = ⊕-specₚ dl r c
+  ... | false = ⊕-specₚ dr r c

--- a/src/Vatras/Lang/ADT/Merge.agda
+++ b/src/Vatras/Lang/ADT/Merge.agda
@@ -23,9 +23,9 @@ module Named (F : 𝔽) where
   This operations inherits all properties of the variant composition (e.g., commutativity, associativity etc).
   -}
   _⊕_ : ∀ {A} → ADT A → ADT A → ADT A
-  leaf l         ⊕ leaf r         = leaf (l +ᵥ r)
-  leaf l         ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
-  (D ⟨ dl , dr ⟩) ⊕ r              = D ⟨ dl ⊕ r , dr ⊕ r ⟩
+  leaf l          ⊕ leaf r          = leaf (l +ᵥ r)
+  leaf l          ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
+  (D ⟨ dl , dr ⟩) ⊕ r               = D ⟨ dl ⊕ r , dr ⊕ r ⟩
 
   ⊕-spec : ∀ {A} (l r : ADT A) (c : Configuration) →
      ⟦ l ⊕ r ⟧ c ≡ ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c

--- a/src/Vatras/Lang/ADT/Merge.agda
+++ b/src/Vatras/Lang/ADT/Merge.agda
@@ -1,0 +1,81 @@
+open import Vatras.Framework.Definitions
+module Vatras.Lang.ADT.Merge
+  (F : 𝔽) (V : 𝕍)
+  (_+ᵥ_ : ∀ {A} → V A → V A → V A)
+  where
+open import Data.Bool using (Bool; if_then_else_; true; false)
+open import Data.Bool.Properties using (if-float)
+open import Relation.Binary.PropositionalEquality using (refl; _≡_; _≗_)
+open Relation.Binary.PropositionalEquality.≡-Reasoning
+
+open import Vatras.Lang.ADT F V
+open import Vatras.Framework.Relation.Expression V
+open import Vatras.Util.AuxProofs using (if-cong; if-swap)
+
+{-|
+Merges two ADTs.
+The resulting ADT denotes all possible compositions of variants, such that configuring the resulting ADT
+is equivalent to configuring both input ADTs and composing the resulting variants (see ⊕-spec below).
+This operations inherits all properties of the variant composition (e.g., commutativity, associativity etc).
+-}
+_⊕_ : ∀ {A} → ADT A → ADT A → ADT A
+leaf l          ⊕ leaf r          = leaf (l +ᵥ r)
+leaf l          ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
+(D ⟨ dl , dr ⟩) ⊕ leaf r          = D ⟨ dl ⊕ leaf r , dr ⊕ leaf r ⟩
+(D ⟨ dl , dr ⟩) ⊕ (E ⟨ el , er ⟩) = D ⟨ E ⟨ dl ⊕ el , dl ⊕ er ⟩ , E ⟨ dr ⊕ el , dr ⊕ er ⟩ ⟩
+
+⊕-spec : ∀ {A} (l r : ADT A) (c : Configuration) →
+   ⟦ l ⊕ r ⟧ c ≡ ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c
+⊕-spec (leaf l)        (leaf r       ) c = refl
+⊕-spec (leaf l)        (E ⟨ el , er ⟩) c =
+  -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
+    ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
+  ≡⟨⟩
+    (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
+  ≡⟨ if-cong (c E) (⊕-spec (leaf l) el c) (⊕-spec (leaf l) er c) ⟩
+    (if c E
+     then ⟦ leaf l ⟧ c +ᵥ ⟦ el ⟧ c
+     else ⟦ leaf l ⟧ c +ᵥ ⟦ er ⟧ c)
+  ≡⟨⟩
+    (if c E
+     then l +ᵥ ⟦ el ⟧ c
+     else l +ᵥ ⟦ er ⟧ c)
+  ≡⟨ if-float (l +ᵥ_) (c E) ⟨
+    l +ᵥ (if c E then ⟦ el ⟧ c else ⟦ er ⟧ c)
+  ≡⟨⟩
+    ⟦ leaf l ⟧ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ c
+  ∎
+⊕-spec (D ⟨ dl , dr ⟩) (leaf r       ) c with c D
+... | true  = ⊕-spec dl (leaf r) c
+... | false = ⊕-spec dr (leaf r) c
+⊕-spec (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
+... | true  | true  = ⊕-spec dl el c
+... | true  | false = ⊕-spec dl er c
+... | false | true  = ⊕-spec dr el c
+... | false | false = ⊕-spec dr er c
+
+-- properties
+
+⊕-comm :
+  (∀ {A} (v w : V A) → v +ᵥ w ≡ w +ᵥ v) →
+  ---------------------------------------------
+  (∀ {A} (l r : ADT A) → ⟦ l ⊕ r ⟧ ≗ ⟦ r ⊕ l ⟧)
+⊕-comm +ᵥ-comm (leaf l       ) (leaf r       ) _ = +ᵥ-comm l r
+⊕-comm +ᵥ-comm (leaf l       ) (E ⟨ el , er ⟩) c =
+    ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
+  ≡⟨⟩
+    (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
+  ≡⟨ if-cong (c E) (⊕-comm +ᵥ-comm (leaf l) el c) (⊕-comm +ᵥ-comm (leaf l) er c) ⟩
+    (if c E then ⟦ el ⊕ leaf l ⟧ c else ⟦ er ⊕ leaf l ⟧ c)
+  ≡⟨⟩
+    ⟦ E ⟨ el ⊕ leaf l , er ⊕ leaf l ⟩ ⟧ c
+  ∎
+⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (leaf r       ) c
+  rewrite ⊕-comm +ᵥ-comm dl (leaf r) c
+        | ⊕-comm +ᵥ-comm dr (leaf r) c
+        = refl
+⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
+... | true  | true  = ⊕-comm +ᵥ-comm dl el c
+... | true  | false = ⊕-comm +ᵥ-comm dl er c
+... | false | true  = ⊕-comm +ᵥ-comm dr el c
+... | false | false = ⊕-comm +ᵥ-comm dr er c

--- a/src/Vatras/Lang/ADT/Merge.agda
+++ b/src/Vatras/Lang/ADT/Merge.agda
@@ -1,6 +1,6 @@
 open import Vatras.Framework.Definitions
 module Vatras.Lang.ADT.Merge
-  (F : 𝔽) (V : 𝕍)
+  (V : 𝕍)
   (_+ᵥ_ : ∀ {A} → V A → V A → V A)
   where
 open import Data.Bool using (Bool; if_then_else_; true; false)
@@ -8,74 +8,126 @@ open import Data.Bool.Properties using (if-float)
 open import Relation.Binary.PropositionalEquality using (refl; _≡_; _≗_)
 open Relation.Binary.PropositionalEquality.≡-Reasoning
 
-open import Vatras.Lang.ADT F V
 open import Vatras.Framework.Relation.Expression V
 open import Vatras.Util.AuxProofs using (if-cong; if-swap)
 
-{-|
-Merges two ADTs.
-The resulting ADT denotes all possible compositions of variants, such that configuring the resulting ADT
-is equivalent to configuring both input ADTs and composing the resulting variants (see ⊕-spec below).
-This operations inherits all properties of the variant composition (e.g., commutativity, associativity etc).
--}
-_⊕_ : ∀ {A} → ADT A → ADT A → ADT A
-leaf l          ⊕ leaf r          = leaf (l +ᵥ r)
-leaf l          ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
-(D ⟨ dl , dr ⟩) ⊕ leaf r          = D ⟨ dl ⊕ leaf r , dr ⊕ leaf r ⟩
-(D ⟨ dl , dr ⟩) ⊕ (E ⟨ el , er ⟩) = D ⟨ E ⟨ dl ⊕ el , dl ⊕ er ⟩ , E ⟨ dr ⊕ el , dr ⊕ er ⟩ ⟩
+import Vatras.Lang.ADT
+module ADT F = Vatras.Lang.ADT F V
 
-⊕-spec : ∀ {A} (l r : ADT A) (c : Configuration) →
-   ⟦ l ⊕ r ⟧ c ≡ ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c
-⊕-spec (leaf l)        (leaf r       ) c = refl
-⊕-spec (leaf l)        (E ⟨ el , er ⟩) c =
-  -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
-    ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
-  ≡⟨⟩
-    (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
-  ≡⟨ if-cong (c E) (⊕-spec (leaf l) el c) (⊕-spec (leaf l) er c) ⟩
-    (if c E
-     then ⟦ leaf l ⟧ c +ᵥ ⟦ el ⟧ c
-     else ⟦ leaf l ⟧ c +ᵥ ⟦ er ⟧ c)
-  ≡⟨⟩
-    (if c E
-     then l +ᵥ ⟦ el ⟧ c
-     else l +ᵥ ⟦ er ⟧ c)
-  ≡⟨ if-float (l +ᵥ_) (c E) ⟨
-    l +ᵥ (if c E then ⟦ el ⟧ c else ⟦ er ⟧ c)
-  ≡⟨⟩
-    ⟦ leaf l ⟧ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ c
-  ∎
-⊕-spec (D ⟨ dl , dr ⟩) (leaf r       ) c with c D
-... | true  = ⊕-spec dl (leaf r) c
-... | false = ⊕-spec dr (leaf r) c
-⊕-spec (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
-... | true  | true  = ⊕-spec dl el c
-... | true  | false = ⊕-spec dl er c
-... | false | true  = ⊕-spec dr el c
-... | false | false = ⊕-spec dr er c
+module Named (F : 𝔽) where
+  open ADT F
 
--- properties
+  {-|
+  Merges two ADTs.
+  The resulting ADT denotes all possible compositions of variants, such that configuring the resulting ADT
+  is equivalent to configuring both input ADTs and composing the resulting variants (see ⊕-spec below).
+  This operations inherits all properties of the variant composition (e.g., commutativity, associativity etc).
+  -}
+  _⊕_ : ∀ {A} → ADT A → ADT A → ADT A
+  leaf l          ⊕ leaf r          = leaf (l +ᵥ r)
+  leaf l          ⊕ (E ⟨ el , er ⟩) = E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩
+  (D ⟨ dl , dr ⟩) ⊕ leaf r          = D ⟨ dl ⊕ leaf r , dr ⊕ leaf r ⟩
+  (D ⟨ dl , dr ⟩) ⊕ (E ⟨ el , er ⟩) = D ⟨ E ⟨ dl ⊕ el , dl ⊕ er ⟩ , E ⟨ dr ⊕ el , dr ⊕ er ⟩ ⟩
 
-⊕-comm :
-  (∀ {A} (v w : V A) → v +ᵥ w ≡ w +ᵥ v) →
-  ---------------------------------------------
-  (∀ {A} (l r : ADT A) → ⟦ l ⊕ r ⟧ ≗ ⟦ r ⊕ l ⟧)
-⊕-comm +ᵥ-comm (leaf l       ) (leaf r       ) _ = +ᵥ-comm l r
-⊕-comm +ᵥ-comm (leaf l       ) (E ⟨ el , er ⟩) c =
-    ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
-  ≡⟨⟩
-    (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
-  ≡⟨ if-cong (c E) (⊕-comm +ᵥ-comm (leaf l) el c) (⊕-comm +ᵥ-comm (leaf l) er c) ⟩
-    (if c E then ⟦ el ⊕ leaf l ⟧ c else ⟦ er ⊕ leaf l ⟧ c)
-  ≡⟨⟩
-    ⟦ E ⟨ el ⊕ leaf l , er ⊕ leaf l ⟩ ⟧ c
-  ∎
-⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (leaf r       ) c
-  rewrite ⊕-comm +ᵥ-comm dl (leaf r) c
-        | ⊕-comm +ᵥ-comm dr (leaf r) c
-        = refl
-⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
-... | true  | true  = ⊕-comm +ᵥ-comm dl el c
-... | true  | false = ⊕-comm +ᵥ-comm dl er c
-... | false | true  = ⊕-comm +ᵥ-comm dr el c
-... | false | false = ⊕-comm +ᵥ-comm dr er c
+  ⊕-spec : ∀ {A} (l r : ADT A) (c : Configuration) →
+     ⟦ l ⊕ r ⟧ c ≡ ⟦ l ⟧ c +ᵥ ⟦ r ⟧ c
+  ⊕-spec (leaf l)        (leaf r       ) c = refl
+  ⊕-spec (leaf l)        (E ⟨ el , er ⟩) c =
+    -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
+      ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
+    ≡⟨⟩
+      (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
+    ≡⟨ if-cong (c E) (⊕-spec (leaf l) el c) (⊕-spec (leaf l) er c) ⟩
+      (if c E
+       then ⟦ leaf l ⟧ c +ᵥ ⟦ el ⟧ c
+       else ⟦ leaf l ⟧ c +ᵥ ⟦ er ⟧ c)
+    ≡⟨⟩
+      (if c E
+       then l +ᵥ ⟦ el ⟧ c
+       else l +ᵥ ⟦ er ⟧ c)
+    ≡⟨ if-float (l +ᵥ_) (c E) ⟨
+      l +ᵥ (if c E then ⟦ el ⟧ c else ⟦ er ⟧ c)
+    ≡⟨⟩
+      ⟦ leaf l ⟧ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ c
+    ∎
+  ⊕-spec (D ⟨ dl , dr ⟩) (leaf r       ) c with c D
+  ... | true  = ⊕-spec dl (leaf r) c
+  ... | false = ⊕-spec dr (leaf r) c
+  ⊕-spec (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
+  ... | true  | true  = ⊕-spec dl el c
+  ... | true  | false = ⊕-spec dl er c
+  ... | false | true  = ⊕-spec dr el c
+  ... | false | false = ⊕-spec dr er c
+
+  ---- Properties ----
+  -- The merge operator inherits
+  -- properties of the variant composition operator.
+  --------------------
+
+  -- import Algebra.Definitions
+  -- module Eq (A : 𝔸) where
+  --   open Algebra.Definitions (_≡_ {A = V A}) using (Commutative) public
+
+  -- module Sem (A : 𝔸) where
+  --   open Algebra.Definitions (_⊢_≣₁_ {A} ADTL) using (Commutative) public
+
+  -- ⊕-comm : ∀ {A} → Eq.Commutative A _+ᵥ_ -> Sem.Commutative A _⊕_
+  ⊕-comm :
+    (∀ {A} (v w : V A) → v +ᵥ w ≡ w +ᵥ v) →
+    ---------------------------------------------
+    (∀ {A} (l r : ADT A) → ⟦ l ⊕ r ⟧ ≗ ⟦ r ⊕ l ⟧)
+  ⊕-comm +ᵥ-comm (leaf l       ) (leaf r       ) _ = +ᵥ-comm l r
+  ⊕-comm +ᵥ-comm (leaf l       ) (E ⟨ el , er ⟩) c =
+      ⟦ E ⟨ leaf l ⊕ el , leaf l ⊕ er ⟩ ⟧ c
+    ≡⟨⟩
+      (if c E then ⟦ leaf l ⊕ el ⟧ c else ⟦ leaf l ⊕ er ⟧ c)
+    ≡⟨ if-cong (c E) (⊕-comm +ᵥ-comm (leaf l) el c) (⊕-comm +ᵥ-comm (leaf l) er c) ⟩
+      (if c E then ⟦ el ⊕ leaf l ⟧ c else ⟦ er ⊕ leaf l ⟧ c)
+    ≡⟨⟩
+      ⟦ E ⟨ el ⊕ leaf l , er ⊕ leaf l ⟩ ⟧ c
+    ∎
+  ⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (leaf r       ) c
+    rewrite ⊕-comm +ᵥ-comm dl (leaf r) c
+          | ⊕-comm +ᵥ-comm dr (leaf r) c
+          = refl
+  ⊕-comm +ᵥ-comm (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with c D | c E
+  ... | true  | true  = ⊕-comm +ᵥ-comm dl el c
+  ... | true  | false = ⊕-comm +ᵥ-comm dl er c
+  ... | false | true  = ⊕-comm +ᵥ-comm dr el c
+  ... | false | false = ⊕-comm +ᵥ-comm dr er c
+
+module Prop (F : 𝔽) where
+  open import Vatras.Data.Prop
+  open ADT (Prop F)
+  open import Vatras.Lang.ADT.Prop F V
+  open Named (Prop F)
+
+  ⊕-specₚ : ∀ {A} (l r : ADT A) (c : Assignment F) →
+     ⟦ l ⊕ r ⟧ₚ c ≡ ⟦ l ⟧ₚ c +ᵥ ⟦ r ⟧ₚ c
+  ⊕-specₚ (leaf v) (leaf r) c = refl
+  ⊕-specₚ (leaf l) (E ⟨ el , er ⟩) c =
+    -- We have to prove one case directly (i.e., without "with" or "rewrite") for termination checking.
+      ⟦ leaf l ⊕ (E ⟨ el , er ⟩) ⟧ₚ c
+    ≡⟨⟩
+      (if eval E c then ⟦ leaf l ⊕ el ⟧ₚ c else ⟦ leaf l ⊕ er ⟧ₚ c)
+    ≡⟨ if-cong (eval E c) (⊕-specₚ (leaf l) el c) (⊕-specₚ (leaf l) er c) ⟩
+      (if eval E c
+       then ⟦ leaf l ⟧ₚ c +ᵥ ⟦ el ⟧ₚ c
+       else ⟦ leaf l ⟧ₚ c +ᵥ ⟦ er ⟧ₚ c)
+    ≡⟨⟩
+      (if eval E c
+       then l +ᵥ ⟦ el ⟧ₚ c
+       else l +ᵥ ⟦ er ⟧ₚ c)
+    ≡⟨ if-float (l +ᵥ_) (eval E c) ⟨
+      l +ᵥ (if eval E c then ⟦ el ⟧ₚ c else ⟦ er ⟧ₚ c)
+    ≡⟨⟩
+      ⟦ leaf l ⟧ₚ c +ᵥ ⟦ E ⟨ el , er ⟩ ⟧ₚ c
+    ∎
+  ⊕-specₚ (D ⟨ dl , dr ⟩) (leaf v) c with eval D c
+  ... | true  = ⊕-specₚ dl (leaf v) c
+  ... | false = ⊕-specₚ dr (leaf v) c
+  ⊕-specₚ (D ⟨ dl , dr ⟩) (E ⟨ el , er ⟩) c with eval D c | eval E c
+  ... | true  | true  = ⊕-specₚ dl el c
+  ... | true  | false = ⊕-specₚ dl er c
+  ... | false | true  = ⊕-specₚ dr el c
+  ... | false | false = ⊕-specₚ dr er c

--- a/src/Vatras/Lang/ADT/Prop.agda
+++ b/src/Vatras/Lang/ADT/Prop.agda
@@ -7,11 +7,7 @@ open import Vatras.Framework.VariabilityLanguage
 open import Vatras.Lang.ADT (Prop F) V
 
 ⟦_⟧ₚ : 𝔼-Semantics V (Assignment F) ADT
-⟦ leaf v      ⟧ₚ c = v
-⟦ D ⟨ l , r ⟩ ⟧ₚ c =
-  if eval D c
-  then ⟦ l ⟧ₚ c
-  else ⟦ r ⟧ₚ c
+⟦ e ⟧ₚ c = ⟦ e ⟧ (λ D → eval D c)
 
 PropADTL : VariabilityLanguage V
 PropADTL = ⟪ ADT , Assignment F , ⟦_⟧ₚ ⟫

--- a/src/Vatras/Lang/ADT/Prop.agda
+++ b/src/Vatras/Lang/ADT/Prop.agda
@@ -1,0 +1,17 @@
+open import Vatras.Framework.Definitions
+module Vatras.Lang.ADT.Prop (F : 𝔽) (V : 𝕍) where
+
+open import Data.Bool using (if_then_else_)
+open import Vatras.Data.Prop using (Prop; Assignment; eval)
+open import Vatras.Framework.VariabilityLanguage
+open import Vatras.Lang.ADT (Prop F) V
+
+⟦_⟧ₚ : 𝔼-Semantics V (Assignment F) ADT
+⟦ leaf v      ⟧ₚ c = v
+⟦ D ⟨ l , r ⟩ ⟧ₚ c =
+  if eval D c
+  then ⟦ l ⟧ₚ c
+  else ⟦ r ⟧ₚ c
+
+PropADTL : VariabilityLanguage V
+PropADTL = ⟪ ADT , Assignment F , ⟦_⟧ₚ ⟫

--- a/src/Vatras/Lang/ADT/Pushdown.agda
+++ b/src/Vatras/Lang/ADT/Pushdown.agda
@@ -1,0 +1,61 @@
+open import Vatras.Framework.Definitions using (𝔸; 𝔽; 𝕍; atoms)
+open import Data.List as List using (List; []; _∷_; _ʳ++_)
+
+module Vatras.Lang.ADT.Pushdown (F : 𝔽) (V : 𝕍)
+  (_-<_>- : ∀ {A} → atoms A → List (V A) → V A)
+  where
+
+open import Data.Bool as Bool using (if_then_else_)
+import Data.Bool.Properties as Bool
+import Data.List.Properties as List
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; _≗_)
+open Eq.≡-Reasoning using (step-≡-⟨; step-≡-⟩; step-≡-∣; _∎)
+open import Size using (Size; ∞)
+
+open import Vatras.Framework.Variants as V using (Rose)
+open import Vatras.Lang.ADT F V
+
+push-down-artifact : ∀ {i : Size} {A : 𝔸} → atoms A → List (ADT A) → ADT A
+push-down-artifact {A = A} a cs = go cs []
+  module push-down-artifact-Implementation where
+  go : ∀ {i : Size} → List (ADT A) → List (V A) → ADT A
+  go [] vs = leaf (a -< List.reverse vs >-)
+  go (leaf v ∷ cs) vs = go cs (v ∷ vs)
+  go (d ⟨ c₁ , c₂ ⟩ ∷ cs) vs = d ⟨ go (c₁ ∷ cs) vs , go (c₂ ∷ cs) vs ⟩
+
+⟦push-down-artifact⟧ : ∀ {i : Size} {A : 𝔸}
+  → (a : atoms A)
+  → (cs : List (ADT A))
+  → (config : Configuration)
+  → ⟦ push-down-artifact a cs ⟧ config ≡ a -< List.map (λ e → ⟦ e ⟧ config) cs >-
+⟦push-down-artifact⟧ {A = A} a cs config = go' cs []
+  where
+  open push-down-artifact-Implementation
+
+  go' : ∀ {i : Size}
+    → (cs' : List (ADT A))
+    → (vs : List (V A))
+    → ⟦ go a cs cs' vs ⟧ config ≡ a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) cs' >-
+  go' [] vs = Eq.sym (Eq.cong₂ _-<_>- refl (Eq.trans (List.ʳ++-defn vs) (List.++-identityʳ (List.reverse vs))))
+  go' (leaf v ∷ cs') vs = Eq.trans (go' cs' (v ∷ vs)) (Eq.cong₂ _-<_>- refl (List.++-ʳ++ List.[ v ] {ys = vs}))
+  go' ((d ⟨ c₁ , c₂ ⟩) ∷ cs') vs =
+      ⟦ d ⟨ go a cs (c₁ ∷ cs') vs , go a cs (c₂ ∷ cs') vs ⟩ ⟧ config
+    ≡⟨⟩
+      (if config d
+        then ⟦ go a cs (c₁ ∷ cs') vs ⟧ config
+        else ⟦ go a cs (c₂ ∷ cs') vs ⟧ config)
+    ≡⟨ Eq.cong₂ (if config d then_else_) (go' (c₁ ∷ cs') vs) (go' (c₂ ∷ cs') vs) ⟩
+      (if config d
+        then a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) (c₁ ∷ cs') >-
+        else a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) (c₂ ∷ cs') >-)
+    ≡⟨ Bool.if-float (λ c → a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) (c ∷ cs') >-) (config d) ⟨
+      a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) ((if config d then c₁ else c₂) ∷ cs') >-
+    ≡⟨⟩
+      a -< vs ʳ++ ⟦ if config d then c₁ else c₂ ⟧ config ∷ List.map (λ e → ⟦ e ⟧ config) cs' >-
+    ≡⟨ Eq.cong₂ _-<_>- refl (Eq.cong₂ _ʳ++_ {x = vs} refl (Eq.cong₂ _∷_ (Bool.if-float (λ e → ⟦ e ⟧ config) (config d)) refl)) ⟩
+      a -< vs ʳ++ (if config d then ⟦ c₁ ⟧ config else ⟦ c₂ ⟧ config) ∷ List.map (λ e → ⟦ e ⟧ config) cs' >-
+    ≡⟨⟩
+      a -< vs ʳ++ ⟦ d ⟨ c₁ , c₂ ⟩ ⟧ config ∷ List.map (λ e → ⟦ e ⟧ config) cs' >-
+    ≡⟨⟩
+      a -< vs ʳ++ List.map (λ e → ⟦ e ⟧ config) (d ⟨ c₁ , c₂ ⟩ ∷ cs') >-
+    ∎

--- a/src/Vatras/Lang/ADT/Pushdown.agda
+++ b/src/Vatras/Lang/ADT/Pushdown.agda
@@ -1,6 +1,11 @@
 open import Vatras.Framework.Definitions using (𝔸; 𝔽; 𝕍; atoms)
 open import Data.List as List using (List; []; _∷_; _ʳ++_)
 
+{-|
+This module provides a function for inserting artifacts at the top of ADTs.
+This operation means that any produced variant will have the given atom at the top.
+The parameter of this module is the constructor for adding an atom on top of existing variants.
+-}
 module Vatras.Lang.ADT.Pushdown (F : 𝔽) (V : 𝕍)
   (_-<_>- : ∀ {A} → atoms A → List (V A) → V A)
   where

--- a/src/Vatras/Lang/ADT/Pushdown.agda
+++ b/src/Vatras/Lang/ADT/Pushdown.agda
@@ -10,14 +10,13 @@ module Vatras.Lang.ADT.Pushdown (F : 𝔽) (V : 𝕍)
   (_-<_>- : ∀ {A} → atoms A → List (V A) → V A)
   where
 
-open import Data.Bool as Bool using (if_then_else_)
+open import Data.Bool using (if_then_else_)
 import Data.Bool.Properties as Bool
 import Data.List.Properties as List
-open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; _≗_)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl)
 open Eq.≡-Reasoning using (step-≡-⟨; step-≡-⟩; step-≡-∣; _∎)
-open import Size using (Size; ∞)
+open import Size using (Size)
 
-open import Vatras.Framework.Variants as V using (Rose)
 open import Vatras.Lang.ADT F V
 
 push-down-artifact : ∀ {i : Size} {A : 𝔸} → atoms A → List (ADT A) → ADT A

--- a/src/Vatras/Lang/All.agda
+++ b/src/Vatras/Lang/All.agda
@@ -20,6 +20,7 @@ import Vatras.Lang.ADT
 import Vatras.Lang.OC
 import Vatras.Lang.FST
 import Vatras.Lang.Gruler
+import Vatras.Lang.VT
 
 open import Data.Empty.Polymorphic using (⊥)
 open import Vatras.Util.Nat.AtLeast using (ℕ≥)
@@ -83,3 +84,8 @@ module Gruler where
   open Vatras.Lang.Gruler using (Gruler; GrulerL; Configuration) public
   module _ {F : 𝔽} where
     open Vatras.Lang.Gruler F hiding (Gruler; GrulerL; Configuration) public
+
+module VT where
+  open Vatras.Lang.VT using (VT; UnrootedVT; VTL; Configuration) public
+  module _ {F : 𝔽} where
+    open Vatras.Lang.VT F hiding (VT; UnrootedVT; VTL; Configuration) public

--- a/src/Vatras/Lang/All/Fixed.agda
+++ b/src/Vatras/Lang/All/Fixed.agda
@@ -13,6 +13,7 @@ import Vatras.Lang.ADT
 import Vatras.Lang.OC
 import Vatras.Lang.FST
 import Vatras.Lang.Gruler
+import Vatras.Lang.VT
 
 module VariantList = Vatras.Lang.VariantList V
 module CCC = Vatras.Lang.CCC F
@@ -27,3 +28,4 @@ module ADT = Vatras.Lang.ADT F V
 module OC = Vatras.Lang.OC F
 module FST = Vatras.Lang.FST F
 module Gruler = Vatras.Lang.Gruler F
+module VT = Vatras.Lang.VT F

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -13,23 +13,23 @@ Conf = Assignment F
 
 data UnrootedVT : 𝔼 where
   _-<_>- : ∀ {A}
-    → atoms A
-    → List (UnrootedVT A)
+    → (a : atoms A)
+    → (l : List (UnrootedVT A))
     → UnrootedVT A
 
   if[_]then[_] : ∀ {A}
-    → Prop F
-    → List (UnrootedVT A)
+    → (p : Prop F)
+    → (l : List (UnrootedVT A))
     → UnrootedVT A
 
   if[_]then[_]else[_] : ∀ {A}
-    → Prop F
-    → List (UnrootedVT A)
-    → List (UnrootedVT A)
+    → (p : Prop F)
+    → (l : List (UnrootedVT A))
+    → (r : List (UnrootedVT A))
     → UnrootedVT A
 
 data VT : 𝔼 where
-  if-true[_] : ∀ {A} → List (UnrootedVT A) → VT A
+  if-true[_] : ∀ {A} → (l : List (UnrootedVT A)) → VT A
 
 vt-leaf : ∀ {A} → atoms A → UnrootedVT A
 vt-leaf a = a -< [] >-

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -40,29 +40,29 @@ mutual
   To prove termination and to simplify proofs, this definition is an inlined variant of
     configure-all c ts = concatMap (configure c) ts
   -}
-  configure-all : ∀ {A} → Configuration → List (UnrootedVT A) → Forest A
-  configure-all c [] = []
-  configure-all c (x ∷ xs) = configure c x ++ configure-all c xs
+  configure-all : ∀ {A} → List (UnrootedVT A) → Configuration → Forest A
+  configure-all [] c       = []
+  configure-all (x ∷ xs) c = configure x c ++ configure-all xs c
 
   {-|
   Corresponds to ⟦_⟧ on artifacts, options, and choices from the dissertation of Paul Bittner.
   -}
-  configure : ∀ {A} → Configuration → UnrootedVT A → Forest A
-  configure c (a -< cs >-)        = a -< configure-all c cs >- ∷ []
-  configure c (if[ p ]then[ t ])  =
+  configure : ∀ {A} → UnrootedVT A → Configuration → Forest A
+  configure (a -< cs >-)       c = a -< configure-all cs c >- ∷ []
+  configure (if[ p ]then[ t ]) c =
     if (eval p c)
-    then configure-all c t
+    then configure-all t c
     else []
-  configure c (if[ p ]then[ t ]else[ e ]) =
+  configure (if[ p ]then[ t ]else[ e ]) c =
     if (eval p c)
-    then configure-all c t
-    else configure-all c e
+    then configure-all t c
+    else configure-all e c
 
 {-|
 Corresponds to ⟦_⟧ on the root term from the dissertation of Paul Bittner.
 -}
 ⟦_⟧ : ∀ {A} → VT A → Configuration → Forest A
-⟦ if-true[ x ] ⟧ c = configure-all c x
+⟦ if-true[ x ] ⟧ = configure-all x
 
 VTL : VariabilityLanguage Forest
 VTL = ⟪ VT , Configuration , ⟦_⟧ ⟫

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -1,5 +1,5 @@
 open import Vatras.Framework.Definitions
-module Vatras.Lang.VariationTree (F : 𝔽) where
+module Vatras.Lang.VT (F : 𝔽) where
 
 open import Data.Bool using (if_then_else_)
 open import Data.List using (List; []; _∷_; map; concatMap)

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -8,8 +8,8 @@ open import Vatras.Data.Prop
 open import Vatras.Framework.Variants using (Rose; Forest; _-<_>-)
 open import Vatras.Framework.VariabilityLanguage
 
-Conf : Set
-Conf = Assignment F
+Configuration : Set
+Configuration = Assignment F
 
 data UnrootedVT : 𝔼 where
   _-<_>- : ∀ {A}
@@ -37,12 +37,12 @@ vt-leaf a = a -< [] >-
 mutual
   -- corresponds to ⟦_⟧*
   {-# TERMINATING #-}
-  configure-all : ∀ {A} → Conf → List (UnrootedVT A) → Forest A
+  configure-all : ∀ {A} → Configuration → List (UnrootedVT A) → Forest A
   configure-all c ts = concatMap (configure c) ts
 
   -- corresponds to ⟦_⟧ on artifacts, options, and choices
   configure :
-    ∀ {A} → Conf → UnrootedVT A → Forest A
+    ∀ {A} → Configuration → UnrootedVT A → Forest A
   configure c (a -< cs >-)        = a -< configure-all c cs >- ∷ []
   configure c (if[ p ]then[ t ])  =
     if (eval p c)
@@ -54,8 +54,8 @@ mutual
     else configure-all c e
 
 -- corresponds to ⟦_⟧ on the root term
-⟦_⟧ : ∀ {A} → VT A → Conf → Forest A
+⟦_⟧ : ∀ {A} → VT A → Configuration → Forest A
 ⟦ if-true[ x ] ⟧ c = configure-all c x
 
 VTL : VariabilityLanguage Forest
-VTL = ⟪ VT , Conf , ⟦_⟧ ⟫
+VTL = ⟪ VT , Configuration , ⟦_⟧ ⟫

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -4,9 +4,9 @@ module Vatras.Lang.VT (F : 𝔽) where
 open import Data.Bool using (if_then_else_)
 open import Data.List using (List; []; _∷_; _++_)
 
-open import Vatras.Data.Prop
-open import Vatras.Framework.Variants using (Rose; Forest; _-<_>-)
-open import Vatras.Framework.VariabilityLanguage
+open import Vatras.Data.Prop using (Prop; Assignment; eval)
+open import Vatras.Framework.Variants using (Forest; _-<_>-)
+open import Vatras.Framework.VariabilityLanguage using (VariabilityLanguage; ⟪_,_,_⟫)
 
 Configuration : Set
 Configuration = Assignment F

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -35,12 +35,18 @@ vt-leaf : ∀ {A} → atoms A → UnrootedVT A
 vt-leaf a = a -< [] >-
 
 mutual
-  -- corresponds to ⟦_⟧*
+  {-|
+  Corresponds to ⟦_⟧* from the dissertation of Paul Bittner.
+  To prove termination and to simplify proofs, this definition is an inlined variant of
+    configure-all c ts = concatMap (configure c) ts
+  -}
   configure-all : ∀ {A} → Configuration → List (UnrootedVT A) → Forest A
   configure-all c [] = []
   configure-all c (x ∷ xs) = configure c x ++ configure-all c xs
 
-  -- corresponds to ⟦_⟧ on artifacts, options, and choices
+  {-|
+  Corresponds to ⟦_⟧ on artifacts, options, and choices from the dissertation of Paul Bittner.
+  -}
   configure :
     ∀ {A} → Configuration → UnrootedVT A → Forest A
   configure c (a -< cs >-)        = a -< configure-all c cs >- ∷ []
@@ -53,7 +59,9 @@ mutual
     then configure-all c t
     else configure-all c e
 
--- corresponds to ⟦_⟧ on the root term
+{-|
+Corresponds to ⟦_⟧ on the root term from the dissertation of Paul Bittner.
+-}
 ⟦_⟧ : ∀ {A} → VT A → Configuration → Forest A
 ⟦ if-true[ x ] ⟧ c = configure-all c x
 

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -31,6 +31,9 @@ data UnrootedVT : 𝔼 where
 data VT : 𝔼 where
   if-true[_] : ∀ {A} → List (UnrootedVT A) → VT A
 
+vt-leaf : ∀ {A} → atoms A → UnrootedVT A
+vt-leaf a = a -< [] >-
+
 mutual
   -- corresponds to ⟦_⟧*
   {-# TERMINATING #-}

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -57,5 +57,5 @@ mutual
 ⟦_⟧ : ∀ {A} → VT A → Conf → Forest A
 ⟦ if-true[ x ] ⟧ c = configure-all c x
 
-VariationTreeVL : VariabilityLanguage Forest
-VariationTreeVL = ⟪ VT , Conf , ⟦_⟧ ⟫
+VTL : VariabilityLanguage Forest
+VTL = ⟪ VT , Conf , ⟦_⟧ ⟫

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -2,7 +2,7 @@ open import Vatras.Framework.Definitions
 module Vatras.Lang.VT (F : 𝔽) where
 
 open import Data.Bool using (if_then_else_)
-open import Data.List using (List; []; _∷_; map; concatMap)
+open import Data.List using (List; []; _∷_; _++_)
 
 open import Vatras.Data.Prop
 open import Vatras.Framework.Variants using (Rose; Forest; _-<_>-)
@@ -36,9 +36,9 @@ vt-leaf a = a -< [] >-
 
 mutual
   -- corresponds to ⟦_⟧*
-  {-# TERMINATING #-}
   configure-all : ∀ {A} → Configuration → List (UnrootedVT A) → Forest A
-  configure-all c ts = concatMap (configure c) ts
+  configure-all c [] = []
+  configure-all c (x ∷ xs) = configure c x ++ configure-all c xs
 
   -- corresponds to ⟦_⟧ on artifacts, options, and choices
   configure :

--- a/src/Vatras/Lang/VT.agda
+++ b/src/Vatras/Lang/VT.agda
@@ -47,8 +47,7 @@ mutual
   {-|
   Corresponds to ⟦_⟧ on artifacts, options, and choices from the dissertation of Paul Bittner.
   -}
-  configure :
-    ∀ {A} → Configuration → UnrootedVT A → Forest A
+  configure : ∀ {A} → Configuration → UnrootedVT A → Forest A
   configure c (a -< cs >-)        = a -< configure-all c cs >- ∷ []
   configure c (if[ p ]then[ t ])  =
     if (eval p c)

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -37,11 +37,11 @@ encode : ∀ {A} → Forest A → VT A
 encode x = if-true[ encode-forest x ]
 
 mutual
-  encode-tree-preserves : ∀ {A} → (T : Rose ∞ A) (c : Conf)
+  encode-tree-preserves : ∀ {A} → (T : Rose ∞ A) (c : Configuration)
     → configure c (encode-tree T) ≡ T ∷ []
   encode-tree-preserves (a -< cs >-) c = Eq.cong (λ eq → (a -< eq >-) ∷ []) (encode-forest-preserves cs c)
 
-  encode-forest-preserves : ∀ {A} (V : Forest A) (c : Conf)
+  encode-forest-preserves : ∀ {A} (V : Forest A) (c : Configuration)
     → configure-all c (encode-forest V) ≡ V
   encode-forest-preserves [] _ = refl
   encode-forest-preserves (x ∷ xs) c =
@@ -67,7 +67,7 @@ mutual
       x ∷ xs
     ∎
 
-encode-preserves : ∀ {A} (V : Forest A) (c : Conf)
+encode-preserves : ∀ {A} (V : Forest A) (c : Configuration)
     → ⟦ encode V ⟧ c ≡ V
 encode-preserves = encode-forest-preserves
 
@@ -75,7 +75,7 @@ encode-preserves = encode-forest-preserves
 Translating configurations is trivial because their values never matter.
 We can do anything here.
 -}
-confs : ⊤ ⇔ Conf
+confs : ⊤ ⇔ Configuration
 confs = record
   { to = λ where tt _ → true
   ; from = λ _ → tt

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -23,8 +23,7 @@ mutual
     a -< map encode-tree xs >-
   -}
   encode-tree : ∀ {A} → Rose ∞ A → UnrootedVT A
-  encode-tree (a -< [] >-)     = a -< [] >-
-  encode-tree (a -< x ∷ xs >-) = a -< encode-tree x ∷ encode-forest xs >-
+  encode-tree (a -< xs >-) = a -< encode-forest xs >-
 
   {-|
   Encodes all trees in a forest to a non-variational
@@ -42,8 +41,7 @@ encode x = if-true[ encode-forest x ]
 mutual
   encode-tree-preserves : ∀ {A} → (T : Rose ∞ A) (c : Configuration)
     → configure c (encode-tree T) ≡ T ∷ []
-  encode-tree-preserves (a -< [] >-)     c = refl
-  encode-tree-preserves (a -< x ∷ xs >-) c = cong (λ eq → (a -< eq >-) ∷ []) (encode-forest-preserves (x ∷ xs) c)
+  encode-tree-preserves (a -< xs >-) c = Eq.cong (λ x → (a -< x >- ∷ [])) (encode-forest-preserves xs c)
 
   encode-forest-preserves : ∀ {A} (V : Forest A) (c : Configuration)
     → configure-all c (encode-forest V) ≡ V

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -1,5 +1,5 @@
 open import Vatras.Framework.Definitions
-module Vatras.Lang.VariationTree.Encode (F : 𝔽) where
+module Vatras.Lang.VT.Encode (F : 𝔽) where
 
 open import Data.Bool using (true)
 open import Data.List using (List; []; _∷_; _++_; map; concat; concatMap)
@@ -11,7 +11,7 @@ open import Size using (∞)
 open import Function using (_∘_)
 
 open import Vatras.Framework.Variants using (Forest; Rose; _-<_>-; Variant-is-VL; VariantEncoder)
-open import Vatras.Lang.VariationTree F
+open import Vatras.Lang.VT F
 
 open import Vatras.Data.EqIndexedSet using (_≅[_][_]_; irrelevant-index-≅)
 open import Vatras.Framework.Relation.Function using (_⇔_; to; from)

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -89,7 +89,7 @@ preserves {A} v = irrelevant-index-≅ v
   (to confs)
   (from confs)
 
-encoder : VariantEncoder Forest VariationTreeVL
+encoder : VariantEncoder Forest VTL
 encoder = record
   { compile = encode
   ; config-compiler = λ _ → confs

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -40,17 +40,17 @@ encode x = if-true[ encode-forest x ]
 
 mutual
   encode-tree-preserves : ∀ {A} → (T : Rose ∞ A) (c : Configuration)
-    → configure c (encode-tree T) ≡ T ∷ []
+    → configure (encode-tree T) c ≡ T ∷ []
   encode-tree-preserves (a -< xs >-) c = Eq.cong (λ x → (a -< x >- ∷ [])) (encode-forest-preserves xs c)
 
   encode-forest-preserves : ∀ {A} (V : Forest A) (c : Configuration)
-    → configure-all c (encode-forest V) ≡ V
+    → configure-all (encode-forest V) c ≡ V
   encode-forest-preserves []       _ = refl
   encode-forest-preserves (x ∷ xs) c =
     begin
-      configure-all c (encode-forest (x ∷ xs))
+      configure-all (encode-forest (x ∷ xs)) c
     ≡⟨⟩
-      configure c (encode-tree x) ++ configure-all c (encode-forest xs)
+      configure (encode-tree x) c ++ configure-all (encode-forest xs) c
     ≡⟨ cong₂ _++_ (encode-tree-preserves x c) (encode-forest-preserves xs c) ⟩
       (x ∷ []) ++ xs
     ≡⟨⟩

--- a/src/Vatras/Lang/VT/Encode.agda
+++ b/src/Vatras/Lang/VT/Encode.agda
@@ -2,10 +2,9 @@ open import Vatras.Framework.Definitions
 module Vatras.Lang.VT.Encode (F : 𝔽) where
 
 open import Data.Bool using (true)
-open import Data.List using (List; []; _∷_; _++_; map; concat; concatMap)
-open import Data.List.Properties using (concatMap-map)
+open import Data.List using (List; []; _∷_; _++_; map)
 open import Data.Unit using (⊤; tt)
-open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; cong₂)
 open Eq.≡-Reasoning
 open import Size using (∞)
 open import Function using (_∘_)
@@ -48,22 +47,10 @@ mutual
     begin
       configure-all c (encode-forest (x ∷ xs))
     ≡⟨⟩
-      configure-all c (map encode-tree (x ∷ xs))
+      configure c (encode-tree x) ++ configure-all c (encode-forest xs)
+    ≡⟨ cong₂ _++_ (encode-tree-preserves x c) (encode-forest-preserves xs c) ⟩
+      (x ∷ []) ++ xs
     ≡⟨⟩
-      concatMap (configure c) (map encode-tree (x ∷ xs))
-    ≡⟨ concatMap-map (configure c) (encode-tree) (x ∷ xs) ⟩
-      concatMap (configure c ∘ encode-tree) (x ∷ xs)
-    ≡⟨⟩
-      concat ((configure c (encode-tree x) ∷ map (configure c ∘ encode-tree) xs))
-    ≡⟨⟩
-      (configure c (encode-tree x)) ++ (concatMap (configure c ∘ encode-tree) xs)
-    ≡⟨ Eq.cong (_++ _) (encode-tree-preserves x c) ⟩
-      (x ∷ []) ++ (concatMap (configure c ∘ encode-tree) xs)
-    ≡⟨⟩
-      x ∷ (concatMap (configure c ∘ encode-tree) xs)
-    ≡⟨ Eq.cong (x ∷_) (concatMap-map (configure c) encode-tree xs) ⟨
-      x ∷ (concatMap (configure c) (map encode-tree xs))
-    ≡⟨ Eq.cong (x ∷_) (encode-forest-preserves xs c) ⟩
       x ∷ xs
     ∎
 

--- a/src/Vatras/Lang/VariantList/Properties.lagda.md
+++ b/src/Vatras/Lang/VariantList/Properties.lagda.md
@@ -5,7 +5,7 @@ These proofs will form the basis for proving these properties for other language
 
 ```
 open import Vatras.Framework.Definitions using (𝕍; 𝔸)
-module Vatras.Lang.VariantList.Properties {V : 𝕍} where
+module Vatras.Lang.VariantList.Properties (V : 𝕍) where
 
 open import Function using (_∘_)
 open import Data.Nat using (ℕ; zero; suc)

--- a/src/Vatras/Test/Test/VariantList-Completeness.agda
+++ b/src/Vatras/Test/Test/VariantList-Completeness.agda
@@ -17,7 +17,7 @@ open import Vatras.Framework.Variants using (Rose)
 Variant = Rose ∞
 open import Vatras.Lang.All.Fixed ⊥ Variant
 open VariantList using (Configuration; ⟦_⟧)
-open import Vatras.Lang.VariantList.Properties {Variant} using (encode; vl-conf; vl-fnoc)
+open import Vatras.Lang.VariantList.Properties Variant using (encode; vl-conf; vl-fnoc)
 open import Vatras.Framework.VariantGenerator Variant using (VariantGenerator)
 
 test-encode-conf : ∀ {A n} → Fin (suc n) → UnitTest (VariantGenerator A n)

--- a/src/Vatras/Translation/Lang/2CC-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/2CC-to-ADT.agda
@@ -10,7 +10,6 @@ module Vatras.Translation.Lang.2CC-to-ADT where
 open import Size using (Size; ∞)
 import Vatras.Data.EqIndexedSet as IndexedSet
 open import Data.Bool as Bool using (if_then_else_)
-import Data.Bool.Properties as Bool
 open import Data.List as List using (List; []; _∷_; _ʳ++_)
 import Data.List.Properties as List
 open import Vatras.Framework.Compiler using (LanguageCompiler)
@@ -28,56 +27,15 @@ open import Vatras.Lang.All
 open 2CC using (2CC; 2CCL; _-<_>-; _⟨_,_⟩)
 open ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
 
-push-down-artifact : ∀ {i : Size} {D : 𝔽} {A : 𝔸} → atoms A → List (ADT D (Rose ∞) A) → ADT D (Rose ∞) A
-push-down-artifact {A = A} a cs = go cs []
-  module push-down-artifact-Implementation where
-  go : ∀ {i : Size} {D : 𝔽} → List (ADT D (Rose ∞) A) → List (Rose ∞ A) → ADT D (Rose ∞) A
-  go [] vs = leaf (a V.-< List.reverse vs >-)
-  go (leaf v ∷ cs) vs = go cs (v ∷ vs)
-  go (d ⟨ c₁ , c₂ ⟩ ∷ cs) vs = d ⟨ go (c₁ ∷ cs) vs , go (c₂ ∷ cs) vs ⟩
+module Pushdown {F : 𝔽} where
+  open import Vatras.Lang.ADT.Pushdown F (Rose ∞) V._-<_>- public
+open Pushdown
 
 translate : ∀ {i : Size} {D : 𝔽} {A : 𝔸}
   → 2CC D i A
   → ADT D (Rose ∞) A
 translate (a -< cs >-) = push-down-artifact a (List.map translate cs)
 translate (d ⟨ l , r ⟩) = d ⟨ translate l , translate r ⟩
-
-⟦push-down-artifact⟧ : ∀ {i : Size} {D : 𝔽} {A : 𝔸}
-  → (a : atoms A)
-  → (cs : List (ADT D (Rose ∞) A))
-  → (config : ADT.Configuration D)
-  → ADT.⟦ push-down-artifact a cs ⟧ config ≡ a V.-< List.map (λ e → ADT.⟦ e ⟧ config) cs >-
-⟦push-down-artifact⟧ {D = D} {A = A} a cs config = go' cs []
-  where
-  open push-down-artifact-Implementation
-
-  go' : ∀ {i : Size}
-    → (cs' : List (ADT D (Rose ∞) A))
-    → (vs : List (Rose ∞ A))
-    → ADT.⟦ go a cs cs' vs ⟧ config ≡ a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) cs' >-
-  go' [] vs = Eq.sym (Eq.cong₂ V._-<_>- refl (Eq.trans (List.ʳ++-defn vs) (List.++-identityʳ (List.reverse vs))))
-  go' (leaf v ∷ cs') vs = Eq.trans (go' cs' (v ∷ vs)) (Eq.cong₂ V._-<_>- refl (List.++-ʳ++ List.[ v ] {ys = vs}))
-  go' ((d ⟨ c₁ , c₂ ⟩) ∷ cs') vs =
-      ADT.⟦ d ⟨ go a cs (c₁ ∷ cs') vs , go a cs (c₂ ∷ cs') vs ⟩ ⟧ config
-    ≡⟨⟩
-      (if config d
-        then ADT.⟦ go a cs (c₁ ∷ cs') vs ⟧ config
-        else ADT.⟦ go a cs (c₂ ∷ cs') vs ⟧ config)
-    ≡⟨ Eq.cong₂ (if config d then_else_) (go' (c₁ ∷ cs') vs) (go' (c₂ ∷ cs') vs) ⟩
-      (if config d
-        then a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) (c₁ ∷ cs') >-
-        else a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) (c₂ ∷ cs') >-)
-    ≡⟨ Bool.if-float (λ c → a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) (c ∷ cs') >-) (config d) ⟨
-      a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) ((if config d then c₁ else c₂) ∷ cs') >-
-    ≡⟨⟩
-      a V.-< vs ʳ++ ADT.⟦ if config d then c₁ else c₂ ⟧ config ∷ List.map (λ e → ADT.⟦ e ⟧ config) cs' >-
-    ≡⟨ Eq.cong₂ V._-<_>- refl (Eq.cong₂ _ʳ++_ {x = vs} refl (Eq.cong₂ _∷_ (Bool.if-float (λ e → ADT.⟦ e ⟧ config) (config d)) refl)) ⟩
-      a V.-< vs ʳ++ (if config d then ADT.⟦ c₁ ⟧ config else ADT.⟦ c₂ ⟧ config) ∷ List.map (λ e → ADT.⟦ e ⟧ config) cs' >-
-    ≡⟨⟩
-      a V.-< vs ʳ++ ADT.⟦ d ⟨ c₁ , c₂ ⟩ ⟧ config ∷ List.map (λ e → ADT.⟦ e ⟧ config) cs' >-
-    ≡⟨⟩
-      a V.-< vs ʳ++ List.map (λ e → ADT.⟦ e ⟧ config) (d ⟨ c₁ , c₂ ⟩ ∷ cs') >-
-    ∎
 
 preserves-≗ : ∀ {i : Size} {D : 𝔽} {A : 𝔸}
   → (expr : 2CC D i A)

--- a/src/Vatras/Translation/Lang/ADT-to-VariantList.agda
+++ b/src/Vatras/Translation/Lang/ADT-to-VariantList.agda
@@ -36,7 +36,7 @@ open import Vatras.Framework.Proof.ForFree V using (soundness-by-expressiveness)
 open import Vatras.Lang.All.Fixed F V
 open ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
 open VariantList using (VariantList; VariantListL)
-open import Vatras.Lang.VariantList.Properties using (VariantList-is-Sound)
+open import Vatras.Lang.VariantList.Properties V using (VariantList-is-Sound)
 
 open import Vatras.Lang.ADT.Path F V _==_
 open import Vatras.Translation.Lang.ADT.DeadElim F V _==_ as DeadElim using (node; kill-dead; ⟦_⟧ᵤ; UndeadADT; UndeadADTL)
@@ -200,4 +200,4 @@ VariantList≽ADT : VariantListL ≽ ADTL
 VariantList≽ADT = expressiveness-from-compiler ADT→VariantList
 
 ADT-is-sound : Sound ADTL
-ADT-is-sound = soundness-by-expressiveness (VariantList-is-Sound {V}) VariantList≽ADT
+ADT-is-sound = soundness-by-expressiveness VariantList-is-Sound VariantList≽ADT

--- a/src/Vatras/Translation/Lang/ADT-to-VariantList.agda
+++ b/src/Vatras/Translation/Lang/ADT-to-VariantList.agda
@@ -18,7 +18,7 @@ open import Function using (_∘_)
 open import Data.List using (List; []; _∷_)
 open import Data.List.NonEmpty using (List⁺; _∷_; _⁺++⁺_; length)
 open import Data.Nat using (ℕ; zero; suc; _+_; _∸_; _<_; _≤?_; z≤n; s≤s)
-open import Data.Nat.Properties using (≤-trans; ≰⇒>; m≤m+n)
+open import Data.Nat.Properties using (≤-trans; ≰⇒>; m≤m+n; +-monoʳ-<)
 open import Data.Product using (_,_)
 
 open import Relation.Nullary.Decidable using (yes; no)
@@ -43,7 +43,6 @@ open import Vatras.Translation.Lang.ADT.DeadElim F V _==_ as DeadElim using (nod
 open import Vatras.Translation.Lang.ADT.WalkSemantics F V _==_ as Walk using ()
 
 open import Vatras.Util.List using (find-or-last; ⁺++⁺-length; ⁺++⁺-length-≤; find-or-last-append; find-or-last-prepend-+; find-or-last-prepend-∸)
-open import Vatras.Util.AuxProofs using (<-cong-+ˡ)
 
 {-
 This translates a ADT to a VariantList.
@@ -93,7 +92,7 @@ conf-bounded (D ⟨ l , r ⟩) ((.D ↣ false ∷ p) is-valid walk-right t) = go
 
     -- add (length (tr l)) to both sides on the left
     gox : length (tr l) + conf r c < length (tr l) + length (tr r)
-    gox = <-cong-+ˡ (length (tr l)) rb
+    gox = +-monoʳ-< (length (tr l)) rb
 
     -- use the sum rule for ⁺++⁺ on the right hand side
     go : length (tr l) + conf r c < length (tr l ⁺++⁺ tr r)

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -49,10 +49,10 @@ elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
 
 ↓-presʳ : ∀ {A} (P : Prop F) (l r : ADT F A)
   → elim-sem P l r ≗ ⟦ ↓ P ⟨ l , r ⟩ ⟧
-↓-presʳ true l r c = refl
-↓-presʳ false l r c = refl
+↓-presʳ true    l r c = refl
+↓-presʳ false   l r c = refl
 ↓-presʳ (var x) l r c = refl
-↓-presʳ (¬ P) l r c =
+↓-presʳ (¬ P)   l r c =
     elim-sem (¬ P) l r c
   ≡⟨⟩
     (if not (eval P c) then ⟦ l ⟧ c else ⟦ r ⟧ c)
@@ -84,11 +84,11 @@ elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
 mutual
   ↓-presˡ : ∀ {A} (P : Prop F) (l r : ADT (Prop F) A)
     → ⟦ P ⟨ l , r ⟩ ⟧ₚ ≗ elim-sem P (elim-formulas l) (elim-formulas r)
-  ↓-presˡ true    l r = preserves l
-  ↓-presˡ false   l r = preserves r
-  ↓-presˡ (var x) l r c = cong₂ (if c x then_else_) (preserves l c) (preserves r c)
-  ↓-presˡ (¬ P)   l r c = cong₂ (if not (eval P c) then_else_) (preserves l c) (preserves r c)
-  ↓-presˡ (P ∧ Q) l r c = cong₂ (if eval P c and eval Q c then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ true    l r c = preserves l c
+  ↓-presˡ false   l r c = preserves r c
+  ↓-presˡ (var x) l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ (¬ P)   l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ (P ∧ Q) l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
 
   preserves
     : ∀ {A}

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -77,7 +77,7 @@ elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
   ≡⟨ if-congˡ (eval P c) (↓-presʳ Q l r c) ⟩
     (if eval P c then ⟦ ↓ Q ⟨ l , r ⟩ ⟧ c else ⟦ r ⟧ c)
   ≡⟨⟩
-    elim-sem P ↓ Q ⟨ l , r ⟩ r c
+    elim-sem P (↓ Q ⟨ l , r ⟩) r c
   ≡⟨ ↓-presʳ P (↓ Q ⟨ l , r ⟩) r c ⟩
     ⟦ ↓ P ⟨ ↓ Q ⟨ l , r ⟩ , r ⟩ ⟧ c
   ∎

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -2,6 +2,7 @@ open import Vatras.Framework.Definitions using (𝔽; 𝕍; 𝔸)
 module Vatras.Translation.Lang.ADT.PropSemantics (F : 𝔽) (V : 𝕍) where
 
 open import Data.Bool using (true; false; if_then_else_; not) renaming (_∧_ to _and_)
+open import Data.Product using (_,_)
 open import Function using (id; _∘_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl)
 open Eq.≡-Reasoning
@@ -16,7 +17,7 @@ open import Vatras.Data.Prop
 open import Vatras.Lang.ADT.Prop F V
 open import Vatras.Util.AuxProofs using (if-flip; if-∧; if-cong; if-congˡ)
 open import Vatras.Framework.Compiler
-
+open import Vatras.Framework.Relation.Expressiveness V using (_≽_; expressiveness-from-compiler)
 
 {-|
 Elimination of formulas in choices.
@@ -109,3 +110,6 @@ formula-elim-compiler = record
   ; config-compiler = λ _ → record { to = id ; from = id }
   ; preserves = ≗→≅[] ∘ preserves
   }
+
+PropADT≽ADT : ADTL F ≽ PropADTL
+PropADT≽ADT = expressiveness-from-compiler formula-elim-compiler

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -1,10 +1,10 @@
 open import Vatras.Framework.Definitions using (𝔽; 𝕍; 𝔸)
 module Vatras.Translation.Lang.ADT.PropSemantics (F : 𝔽) (V : 𝕍) where
 
-open import Data.Bool using (true; false; if_then_else_; not) renaming (_∧_ to _and_)
+open import Data.Bool using (if_then_else_; not) renaming (_∧_ to _and_)
 open import Data.Product using (_,_)
 open import Function using (id; _∘_)
-open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl)
+open import Relation.Binary.PropositionalEquality as Eq using (_≗_; refl)
 open Eq.≡-Reasoning
 
 import Vatras.Lang.ADT
@@ -16,7 +16,7 @@ open import Vatras.Data.EqIndexedSet using (≗→≅[])
 open import Vatras.Data.Prop
 open import Vatras.Lang.ADT.Prop F V
 open import Vatras.Util.AuxProofs using (if-flip; if-∧; if-cong; if-congˡ)
-open import Vatras.Framework.Compiler
+open import Vatras.Framework.Compiler using (LanguageCompiler)
 open import Vatras.Framework.Relation.Expressiveness V using (_≽_; expressiveness-from-compiler)
 
 {-|

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -1,0 +1,111 @@
+open import Vatras.Framework.Definitions using (𝔽; 𝕍; 𝔸)
+module Vatras.Translation.Lang.ADT.PropSemantics (F : 𝔽) (V : 𝕍) where
+
+open import Data.Bool using (true; false; if_then_else_; not) renaming (_∧_ to _and_)
+open import Function using (id; _∘_)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl; cong; cong₂)
+open Eq.≡-Reasoning
+
+import Vatras.Lang.ADT
+module ADT F = Vatras.Lang.ADT F V
+open ADT hiding (⟦_⟧)
+⟦_⟧ = ADT.⟦_⟧ F
+
+open import Vatras.Data.EqIndexedSet using (≗→≅[])
+open import Vatras.Data.Prop
+open import Vatras.Lang.ADT.Prop F V
+open import Vatras.Util.AuxProofs using (if-flip; if-∧)
+open import Vatras.Framework.Compiler
+
+
+{-|
+Elimination of formulas in choices.
+The elimination uses the transformation rules of the formula choice calculus.
+We use this auxiliary function solely for termination checking.
+Note that this function is actually independent of ADTs, so we can potentially generalize it to choices for any language.
+All it takes is a choice constructor.
+-}
+↓_⟨_,_⟩ : ∀ {A} → Prop F → ADT F A → ADT F A → ADT F A
+↓ true  ⟨ l , _ ⟩ = l
+↓ false ⟨ _ , r ⟩ = r
+↓ var X ⟨ l , r ⟩ = X ⟨ l , r ⟩
+↓ ¬ P   ⟨ l , r ⟩ = ↓ P ⟨ r , l ⟩
+↓ P ∧ Q ⟨ l , r ⟩ = ↓ P ⟨ ↓ Q ⟨ l , r ⟩ , r ⟩
+
+elim-formulas : ∀ {A} → ADT (Prop F) A → ADT F A
+elim-formulas (leaf v)      = leaf v
+elim-formulas (P ⟨ l , r ⟩) = ↓ P ⟨ elim-formulas l , elim-formulas r ⟩
+
+---- Preservation Proofs ----
+
+{-|
+Intermediary semantics for choices whose formulas are about to be eliminated.
+The alternatives are already transformed.
+We need this intermediary semantics to convince the termination checker that our proof uses
+well-founded induction.
+-}
+elim-sem : ∀ {A} → Prop F → (l r : ADT F A) → Configuration F → V A
+elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
+
+↓-presʳ : ∀ {A} (P : Prop F) (l r : ADT F A)
+  → elim-sem P l r ≗ ⟦ ↓ P ⟨ l , r ⟩ ⟧
+↓-presʳ true l r c = refl
+↓-presʳ false l r c = refl
+↓-presʳ (var x) l r c = refl
+↓-presʳ (¬ P) l r c =
+    elim-sem (¬ P) l r c
+  ≡⟨⟩
+    (if not (eval P c) then ⟦ l ⟧ c else ⟦ r ⟧ c)
+  ≡⟨ if-flip (eval P c) _ _ ⟩
+    (if eval P c then ⟦ r ⟧ c else ⟦ l ⟧ c)
+  ≡⟨⟩
+    elim-sem P r l c
+  ≡⟨ ↓-presʳ P r l c ⟩
+    ⟦ ↓ P ⟨ r , l ⟩ ⟧ c
+  ≡⟨⟩
+    ⟦ ↓ (¬ P) ⟨ l , r ⟩ ⟧ c
+  ∎
+↓-presʳ (P ∧ Q) l r c =
+    elim-sem (P ∧ Q) l r c
+  ≡⟨⟩
+    (if eval P c and eval Q c then ⟦ l ⟧ c else ⟦ r ⟧ c)
+  ≡⟨ if-∧ (eval P c) (eval Q c) _ _ ⟩
+    (if eval P c then (if eval Q c then ⟦ l ⟧ c else ⟦ r ⟧ c) else ⟦ r ⟧ c)
+  ≡⟨⟩
+    (if eval P c then elim-sem Q l r c else ⟦ r ⟧ c)
+  ≡⟨ cong (if eval P c then_else ⟦ r ⟧ c) (↓-presʳ Q l r c) ⟩
+    (if eval P c then ⟦ ↓ Q ⟨ l , r ⟩ ⟧ c else ⟦ r ⟧ c)
+  ≡⟨⟩
+    elim-sem P ↓ Q ⟨ l , r ⟩ r c
+  ≡⟨ ↓-presʳ P (↓ Q ⟨ l , r ⟩) r c ⟩
+    ⟦ ↓ P ⟨ ↓ Q ⟨ l , r ⟩ , r ⟩ ⟧ c
+  ∎
+
+mutual
+  ↓-presˡ : ∀ {A} (P : Prop F) (l r : ADT (Prop F) A)
+    → ⟦ P ⟨ l , r ⟩ ⟧ₚ ≗ elim-sem P (elim-formulas l) (elim-formulas r)
+  ↓-presˡ true    l r = preserves l
+  ↓-presˡ false   l r = preserves r
+  ↓-presˡ (var x) l r c = cong₂ (if c x then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ (¬ P)   l r c = cong₂ (if not (eval P c) then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ (P ∧ Q) l r c = cong₂ (if eval P c and eval Q c then_else_) (preserves l c) (preserves r c)
+
+  preserves
+    : ∀ {A}
+    → (e : ADT (Prop F) A)
+    → ⟦ e ⟧ₚ ≗ ⟦ elim-formulas e ⟧
+  preserves (leaf _) _ = refl
+  preserves (D ⟨ l , r ⟩) c =
+      ⟦ D ⟨ l , r ⟩ ⟧ₚ c
+    ≡⟨ ↓-presˡ D l r c ⟩
+      elim-sem D (elim-formulas l) (elim-formulas r) c
+    ≡⟨ ↓-presʳ D (elim-formulas l) (elim-formulas r) c ⟩
+      ⟦ ↓ D ⟨ elim-formulas l , elim-formulas r ⟩ ⟧ c
+    ∎
+
+formula-elim-compiler : LanguageCompiler PropADTL (ADTL F)
+formula-elim-compiler = record
+  { compile = elim-formulas
+  ; config-compiler = λ _ → record { to = id ; from = id }
+  ; preserves = ≗→≅[] ∘ preserves
+  }

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -3,7 +3,7 @@ module Vatras.Translation.Lang.ADT.PropSemantics (F : 𝔽) (V : 𝕍) where
 
 open import Data.Bool using (true; false; if_then_else_; not) renaming (_∧_ to _and_)
 open import Function using (id; _∘_)
-open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl; cong; cong₂)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl)
 open Eq.≡-Reasoning
 
 import Vatras.Lang.ADT
@@ -14,7 +14,7 @@ open ADT hiding (⟦_⟧)
 open import Vatras.Data.EqIndexedSet using (≗→≅[])
 open import Vatras.Data.Prop
 open import Vatras.Lang.ADT.Prop F V
-open import Vatras.Util.AuxProofs using (if-flip; if-∧)
+open import Vatras.Util.AuxProofs using (if-flip; if-∧; if-cong; if-congˡ)
 open import Vatras.Framework.Compiler
 
 
@@ -73,7 +73,7 @@ elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
     (if eval P c then (if eval Q c then ⟦ l ⟧ c else ⟦ r ⟧ c) else ⟦ r ⟧ c)
   ≡⟨⟩
     (if eval P c then elim-sem Q l r c else ⟦ r ⟧ c)
-  ≡⟨ cong (if eval P c then_else ⟦ r ⟧ c) (↓-presʳ Q l r c) ⟩
+  ≡⟨ if-congˡ (eval P c) (↓-presʳ Q l r c) ⟩
     (if eval P c then ⟦ ↓ Q ⟨ l , r ⟩ ⟧ c else ⟦ r ⟧ c)
   ≡⟨⟩
     elim-sem P ↓ Q ⟨ l , r ⟩ r c
@@ -86,9 +86,9 @@ mutual
     → ⟦ P ⟨ l , r ⟩ ⟧ₚ ≗ elim-sem P (elim-formulas l) (elim-formulas r)
   ↓-presˡ true    l r c = preserves l c
   ↓-presˡ false   l r c = preserves r c
-  ↓-presˡ (var x) l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
-  ↓-presˡ (¬ P)   l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
-  ↓-presˡ (P ∧ Q) l r c = cong₂ (if _ then_else_) (preserves l c) (preserves r c)
+  ↓-presˡ (var x) l r c = if-cong _ (preserves l c) (preserves r c)
+  ↓-presˡ (¬ P)   l r c = if-cong _ (preserves l c) (preserves r c)
+  ↓-presˡ (P ∧ Q) l r c = if-cong _ (preserves l c) (preserves r c)
 
   preserves
     : ∀ {A}

--- a/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
+++ b/src/Vatras/Translation/Lang/ADT/PropSemantics.agda
@@ -85,11 +85,7 @@ elim-sem P l r c = if eval P c then ⟦ l ⟧ c else ⟦ r ⟧ c
 mutual
   ↓-presˡ : ∀ {A} (P : Prop F) (l r : ADT (Prop F) A)
     → ⟦ P ⟨ l , r ⟩ ⟧ₚ ≗ elim-sem P (elim-formulas l) (elim-formulas r)
-  ↓-presˡ true    l r c = preserves l c
-  ↓-presˡ false   l r c = preserves r c
-  ↓-presˡ (var x) l r c = if-cong _ (preserves l c) (preserves r c)
-  ↓-presˡ (¬ P)   l r c = if-cong _ (preserves l c) (preserves r c)
-  ↓-presˡ (P ∧ Q) l r c = if-cong _ (preserves l c) (preserves r c)
+  ↓-presˡ P l r c = if-cong _ (preserves l c) (preserves r c)
 
   preserves
     : ∀ {A}

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -1,0 +1,108 @@
+open import Vatras.Framework.Definitions using (𝔽; 𝔸; atoms; NAT)
+module Vatras.Translation.Lang.VT-to-ADT (F : 𝔽) where
+
+open import Data.Bool using (true; false)
+open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl)
+
+open import Vatras.Data.Prop
+open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp; rose-leaf; forest-leaf; forest-singleton; _-<_>-)
+open import Vatras.Lang.ADT (Prop F) Forest as ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
+open import Vatras.Lang.ADT.Prop F Forest
+-- open import Vatras.Lang.ADT.Pushdown (Prop F) Forest _-<_>-∷[]
+open import Vatras.Lang.VT F as VT using (VT; UnrootedVT; _-<_>-; if-true[_]; if[_]then[_]; if[_]then[_]else[_]; vt-leaf)
+
+-- translate-all : ∀ {A} → List (UnrootedVT A) → List (ADT A)
+-- translate-all []                               = []
+-- translate-all (a -< l >- ∷ xs)                 = push-down-artifact a {!l xs!} ∷ translate-all xs
+-- translate-all (if[ p ]then[ x ] ∷ xs)          = p ⟨ translate-all (x ++ xs) , translate-all xs ⟩ ∷ []
+-- translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-all l , translate-all r ⟩ ∷ translate-all xs
+
+-- translate : ∀ {A} → VT A → ADT A
+-- translate if-true[ l ] = translate-all l
+
+module _ {A : 𝔸} where
+  -- artifact atom, artifact children, artifact neighbors
+  pushy : atoms A → ADT A → ADT A → ADT A
+  pushy a (D ⟨ l , r ⟩) n             = D ⟨ pushy a l n , pushy a r n ⟩
+  pushy a (leaf v)      (leaf v')     = leaf (a -< v >- ∷ v')
+  pushy a c@(leaf v)    (D ⟨ l , r ⟩) = D ⟨ pushy a c l , pushy a c r ⟩
+
+  {-# TERMINATING #-}
+  translate-all : List (UnrootedVT A) → ADT A
+  translate-all []                               = leaf []
+  translate-all (a -< l >- ∷ xs)                 = pushy a (translate-all l) (translate-all xs)
+  translate-all (if[ p ]then[ l ] ∷ xs)          = p ⟨ translate-all (l ++ xs) , translate-all xs ⟩
+  translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-all (l ++ xs) , translate-all (r ++ xs) ⟩
+
+  translate : VT A → ADT A
+  translate if-true[ xs ] = translate-all xs
+
+module Test {A : 𝔸} where
+  module Forest (a b : atoms A) where
+    vt : VT A
+    vt =
+      if-true[
+        vt-leaf a ∷ vt-leaf b ∷ []
+      ]
+  
+    adt : ADT A
+    adt = leaf (rose-leaf a ∷ rose-leaf b ∷ [])
+  
+    tr : translate vt ≡ adt
+    tr = refl
+  
+    pres : VT.⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
+    pres _ = refl
+
+  module SingleOption (X : Prop F) (a b : atoms A) where
+    vt : VT A
+    vt =
+      if-true[
+        a -<
+          if[ X ]then[
+            vt-leaf b ∷ []
+          ] ∷ []
+        >- ∷ []
+      ]
+
+    adt : ADT A
+    adt = X ⟨ leaf (forest-singleton a (forest-leaf b)) , leaf (forest-leaf a) ⟩
+  
+    tr : translate vt ≡ adt
+    tr = refl
+
+    pres-t : VT.⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
+    pres-t c with eval X c
+    ... | true  = refl
+    ... | false = refl
+
+  module SingleChoice (X : Prop F) (a b₁ b₂ e₁ e₂ : atoms A) where
+    vt : VT A
+    vt =
+      if-true[
+        a -<
+          if[ X ]then[
+            vt-leaf b₁ ∷
+            vt-leaf b₂ ∷ []
+          ]else[
+            vt-leaf e₁ ∷
+            vt-leaf e₂ ∷ []
+          ] ∷ []
+        >- ∷ []
+      ]
+
+    adt : ADT A
+    adt =
+      X ⟨
+        leaf (forest-singleton a (rose-leaf b₁ ∷ rose-leaf b₂ ∷ [])) ,
+        leaf (forest-singleton a (rose-leaf e₁ ∷ rose-leaf e₂ ∷ []))
+      ⟩
+
+    tr : translate vt ≡ adt
+    tr = refl
+
+    pres-t : VT.⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
+    pres-t c with eval X c
+    ... | true  = refl
+    ... | false = refl

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -71,14 +71,14 @@ translate if-true[ xs ] = translate-all xs
 
 -- Preservation Proofs --
 
-preserves-all : ∀ {A} (vts : List (UnrootedVT A)) → flip configure-all vts ≗ ⟦ translate-all vts ⟧ₚ
+preserves-all : ∀ {A} (vts : List (UnrootedVT A)) → configure-all vts ≗ ⟦ translate-all vts ⟧ₚ
 preserves-all [] c = refl
 preserves-all (a -< l >- ∷ xs) c =
-    flip configure-all (a -< l >- ∷ xs) c
+    configure-all (a -< l >- ∷ xs) c
   ≡⟨⟩
-    a -< configure-all c l >- ∷ configure-all c xs
+    a -< configure-all l c >- ∷ configure-all xs c
   ≡⟨ cong (_ ∷_) (preserves-all xs c) ⟩
-    a -< configure-all c l >- ∷ ⟦ translate-all xs ⟧ₚ c
+    a -< configure-all l c >- ∷ ⟦ translate-all xs ⟧ₚ c
   ≡⟨ cong (λ z → a -< z >- ∷ _) (preserves-all l c) ⟩
     a -< ⟦ translate-all l ⟧ₚ c >- ∷ ⟦ translate-all xs ⟧ₚ c
   ≡⟨ push-down-left-spec a (translate-all l) (translate-all xs) c ⟨
@@ -86,7 +86,7 @@ preserves-all (a -< l >- ∷ xs) c =
   ∎
 preserves-all (if[ p ]then[ l ] ∷ xs) c with eval p c
 ... | true  =
-    configure-all c l ++ configure-all c xs
+    configure-all l c ++ configure-all xs c
   ≡⟨ cong₂ _++_ (preserves-all l c) (preserves-all xs c) ⟩
     ⟦ translate-all l ⟧ₚ c ++ ⟦ translate-all xs ⟧ₚ c
   ≡⟨ ⊕-specₚ (translate-all l) (translate-all xs) c ⟨

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -1,42 +1,94 @@
 open import Vatras.Framework.Definitions using (𝔽; 𝔸; atoms; NAT)
 module Vatras.Translation.Lang.VT-to-ADT (F : 𝔽) where
 
-open import Data.Bool using (true; false)
+open import Data.Bool using (true; false; if_then_else_)
 open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
-open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl)
+open import Data.List.Properties using (++-identityʳ; ++-assoc)
+open import Function using (flip)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl; cong; cong₂)
+open Eq.≡-Reasoning
 
 open import Vatras.Data.Prop
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp; rose-leaf; forest-leaf; forest-singleton; _-<_>-)
 open import Vatras.Lang.ADT (Prop F) Forest as ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
-open import Vatras.Lang.ADT.Prop F Forest
--- open import Vatras.Lang.ADT.Pushdown (Prop F) Forest _-<_>-∷[]
-open import Vatras.Lang.VT F as VT using (VT; UnrootedVT; _-<_>-; if-true[_]; if[_]then[_]; if[_]then[_]else[_]; vt-leaf)
+open import Vatras.Lang.VT F as VT using (VT; UnrootedVT; ⟦_⟧; _-<_>-; if-true[_]; if[_]then[_]; if[_]then[_]else[_]; vt-leaf; configure; configure-all)
+open import Vatras.Util.AuxProofs using (if-cong)
 
--- translate-all : ∀ {A} → List (UnrootedVT A) → List (ADT A)
--- translate-all []                               = []
--- translate-all (a -< l >- ∷ xs)                 = push-down-artifact a {!l xs!} ∷ translate-all xs
--- translate-all (if[ p ]then[ x ] ∷ xs)          = p ⟨ translate-all (x ++ xs) , translate-all xs ⟩ ∷ []
--- translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-all l , translate-all r ⟩ ∷ translate-all xs
-
--- translate : ∀ {A} → VT A → ADT A
--- translate if-true[ l ] = translate-all l
+open import Vatras.Lang.ADT.Prop F Forest using (⟦_⟧ₚ)
+open import Vatras.Lang.ADT.Merge Forest (_++_) as Merge
+open Merge.Named (Prop F) using (_⊕_)
+open Merge.Prop F using (⊕-specₚ)
 
 module _ {A : 𝔸} where
   -- artifact atom, artifact children, artifact neighbors
   pushy : atoms A → ADT A → ADT A → ADT A
-  pushy a (D ⟨ l , r ⟩) n             = D ⟨ pushy a l n , pushy a r n ⟩
   pushy a (leaf v)      (leaf v')     = leaf (a -< v >- ∷ v')
   pushy a c@(leaf v)    (D ⟨ l , r ⟩) = D ⟨ pushy a c l , pushy a c r ⟩
+  pushy a (D ⟨ l , r ⟩) n             = D ⟨ pushy a l n , pushy a r n ⟩
 
-  {-# TERMINATING #-}
-  translate-all : List (UnrootedVT A) → ADT A
-  translate-all []                               = leaf []
-  translate-all (a -< l >- ∷ xs)                 = pushy a (translate-all l) (translate-all xs)
-  translate-all (if[ p ]then[ l ] ∷ xs)          = p ⟨ translate-all (l ++ xs) , translate-all xs ⟩
-  translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-all (l ++ xs) , translate-all (r ++ xs) ⟩
+  mutual
+    translate-both : (l r : List (UnrootedVT A)) → ADT A
+    translate-both l r = translate-all l ⊕ translate-all r
+
+    translate-all : List (UnrootedVT A) → ADT A
+    translate-all []                               = leaf []
+    translate-all (a -< l >- ∷ xs)                 = pushy a (translate-all l) (translate-all xs)
+    translate-all (if[ p ]then[ l ] ∷ xs)          = p ⟨ translate-both l xs , translate-all xs ⟩
+    translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-both l xs , translate-both r xs ⟩
 
   translate : VT A → ADT A
   translate if-true[ xs ] = translate-all xs
+
+  -- Preservation Proofs --
+  
+  -- formal specification of pushy: It should create an ADT such that for any configuration c, there is an artifact at the top of left
+  pushy-preserves : ∀ a l n c → ⟦ pushy a l n ⟧ₚ c ≡ a -< ⟦ l ⟧ₚ c >- ∷ ⟦ n ⟧ₚ c
+  pushy-preserves a (leaf v) (leaf v') c = refl
+  pushy-preserves a (D ⟨ l , r ⟩) n c with eval D c
+  ... | true  = pushy-preserves a l n c
+  ... | false = pushy-preserves a r n c
+  pushy-preserves a x@(leaf v) (D ⟨ l , r ⟩) c with eval D c
+  ... | true  = pushy-preserves a x l c
+  ... | false = pushy-preserves a x r c
+
+  preserves-all : ∀ (vts : List (UnrootedVT A)) → flip configure-all vts ≗ ⟦ translate-all vts ⟧ₚ
+  preserves-all [] c = refl
+  preserves-all (a -< l >- ∷ xs) c =
+      flip configure-all (a -< l >- ∷ xs) c
+    ≡⟨⟩
+      a -< configure-all c l >- ∷ configure-all c xs
+    ≡⟨ cong (_ ∷_) (preserves-all xs c) ⟩
+      a -< configure-all c l >- ∷ ⟦ translate-all xs ⟧ₚ c
+    ≡⟨ cong (λ z → a -< z >- ∷ _) (preserves-all l c) ⟩
+      a -< ⟦ translate-all l ⟧ₚ c >- ∷ ⟦ translate-all xs ⟧ₚ c
+    ≡⟨ pushy-preserves a (translate-all l) (translate-all xs) c ⟨
+      ⟦ pushy a (translate-all l) (translate-all xs) ⟧ₚ c
+    ∎
+  preserves-all (if[ p ]then[ l ] ∷ xs) c with eval p c
+  ... | true  =
+      configure-all c l ++ configure-all c xs
+    ≡⟨ cong₂ _++_ (preserves-all l c) (preserves-all xs c) ⟩
+      ⟦ translate-all l ⟧ₚ c ++ ⟦ translate-all xs ⟧ₚ c
+    ≡⟨ ⊕-specₚ (translate-all l) (translate-all xs) c ⟨
+      ⟦ translate-all l ⊕ translate-all xs ⟧ₚ c
+    ≡⟨⟩
+      ⟦ translate-both l xs ⟧ₚ c
+    ∎
+  ... | false = preserves-all xs c
+  preserves-all (if[ p ]then[ l ]else[ r ] ∷ xs) c with eval p c -- the cases for the choice alternatives are analogous to the first option case above
+  ... | true
+    rewrite preserves-all l c
+          | preserves-all xs c
+          | ⊕-specₚ (translate-all l) (translate-all xs) c
+          = refl
+  ... | false
+    rewrite preserves-all r c
+          | preserves-all xs c
+          | ⊕-specₚ (translate-all r) (translate-all xs) c
+          = refl
+
+  preserves : ∀ (vt : VT A) → ⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
+  preserves if-true[ xs ] c = preserves-all xs c
 
 module Test {A : 𝔸} where
   module Forest (a b : atoms A) where

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -113,20 +113,20 @@ preserves-all (if[ p ]then[ l ]else[ r ] ∷ xs) c with eval p c
 preserves : ∀ {A} (vt : VT A) → ⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
 preserves if-true[ xs ] c = preserves-all xs c
 
-VT→PropADT : LanguageCompiler VariationTreeVL PropADTL
+VT→PropADT : LanguageCompiler VTL PropADTL
 VT→PropADT = record
   { compile = translate
   ; config-compiler = λ _ → record { to = id ; from = id }
   ; preserves = ≗→≅[] ∘ preserves
   }
 
-PropADT≽VT : PropADTL ≽ VariationTreeVL
+PropADT≽VT : PropADTL ≽ VTL
 PropADT≽VT = expressiveness-from-compiler VT→PropADT
 
-VT→ADT : LanguageCompiler VariationTreeVL ADTL
+VT→ADT : LanguageCompiler VTL ADTL
 VT→ADT = VT→PropADT Compiler.⊕ formula-elim-compiler
 
-ADT≽VT : ADTL ≽ VariationTreeVL
+ADT≽VT : ADTL ≽ VTL
 ADT≽VT = ≽-trans PropADT≽ADT PropADT≽VT
 
 {-|

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -51,10 +51,10 @@ push-down-left-spec a x@(leaf v) (D ⟨ l , r ⟩) c with eval D c
 mutual
   {-|
   We need this auxiliary function to prove termination.
-  Given two lists l, r of neighboring variation tree nodes, we translate
-  cannot translate them via
+  Given two lists l, r of neighboring variation tree nodes,
+  we cannot translate them via
     translate-all (l ++ r)
-  but translate both lists first, and them compose the result
+  but can translate both lists first, and them compose the result
     translate-all l ⊕ translate-all r.
   -}
   translate-both : ∀ {A} → (l r : List (UnrootedVT A)) → ADT A

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -1,15 +1,13 @@
-open import Vatras.Framework.Definitions using (𝔽; 𝔸; atoms; NAT)
+open import Vatras.Framework.Definitions using (𝔽; 𝔸; atoms)
 module Vatras.Translation.Lang.VT-to-ADT (F : 𝔽) where
 
-open import Data.Bool using (true; false; if_then_else_)
-open import Data.List as List using (List; []; _∷_; _++_)
-open import Data.List.Properties using (++-identityʳ; ++-assoc)
-open import Data.Product using (_,_)
+open import Data.Bool using (true; false)
+open import Data.List using (List; []; _∷_; _++_)
 open import Function using (id; _∘_; flip)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl; cong; cong₂)
 open Eq.≡-Reasoning
 
-open import Vatras.Data.Prop
+open import Vatras.Data.Prop using (Prop; eval)
 open import Vatras.Data.EqIndexedSet using (≗→≅[])
 open import Vatras.Framework.Variants using (Forest; _-<_>-)
 open import Vatras.Framework.Compiler as Compiler using (LanguageCompiler)

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -4,20 +4,25 @@ module Vatras.Translation.Lang.VT-to-ADT (F : 𝔽) where
 open import Data.Bool using (true; false; if_then_else_)
 open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
 open import Data.List.Properties using (++-identityʳ; ++-assoc)
-open import Function using (flip)
+open import Data.Product using (_,_)
+open import Function using (id; _∘_; flip)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; _≗_; refl; cong; cong₂)
 open Eq.≡-Reasoning
 
 open import Vatras.Data.Prop
+open import Vatras.Data.EqIndexedSet using (≗→≅[]; ≗→≅)
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp; rose-leaf; forest-leaf; forest-singleton; _-<_>-)
+open import Vatras.Framework.Compiler using (LanguageCompiler)
 open import Vatras.Lang.ADT (Prop F) Forest as ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
-open import Vatras.Lang.VT F as VT using (VT; UnrootedVT; ⟦_⟧; _-<_>-; if-true[_]; if[_]then[_]; if[_]then[_]else[_]; vt-leaf; configure; configure-all)
+open import Vatras.Lang.VT F as VT
 open import Vatras.Util.AuxProofs using (if-cong)
 
-open import Vatras.Lang.ADT.Prop F Forest using (⟦_⟧ₚ)
+open import Vatras.Lang.ADT.Prop F Forest using (⟦_⟧ₚ; PropADTL)
 open import Vatras.Lang.ADT.Merge Forest (_++_) as Merge
 open Merge.Named (Prop F) using (_⊕_)
 open Merge.Prop F using (⊕-specₚ)
+
+open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_)
 
 module _ {A : 𝔸} where
   -- artifact atom, artifact children, artifact neighbors
@@ -89,6 +94,16 @@ module _ {A : 𝔸} where
 
   preserves : ∀ (vt : VT A) → ⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
   preserves if-true[ xs ] c = preserves-all xs c
+
+VT→PropADT : LanguageCompiler VariationTreeVL PropADTL
+VT→PropADT = record
+  { compile = translate
+  ; config-compiler = λ _ → record { to = id ; from = id }
+  ; preserves = ≗→≅[] ∘ preserves
+  }
+
+PropADT≽VT : PropADTL ≽ VariationTreeVL
+PropADT≽VT e = translate e , ≗→≅ (preserves e)
 
 module Test {A : 𝔸} where
   module Forest (a b : atoms A) where

--- a/src/Vatras/Translation/Lang/VT-to-ADT.agda
+++ b/src/Vatras/Translation/Lang/VT-to-ADT.agda
@@ -2,7 +2,7 @@ open import Vatras.Framework.Definitions using (𝔽; 𝔸; atoms; NAT)
 module Vatras.Translation.Lang.VT-to-ADT (F : 𝔽) where
 
 open import Data.Bool using (true; false; if_then_else_)
-open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
+open import Data.List as List using (List; []; _∷_; _++_)
 open import Data.List.Properties using (++-identityʳ; ++-assoc)
 open import Data.Product using (_,_)
 open import Function using (id; _∘_; flip)
@@ -11,7 +11,7 @@ open Eq.≡-Reasoning
 
 open import Vatras.Data.Prop
 open import Vatras.Data.EqIndexedSet using (≗→≅[]; ≗→≅)
-open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp; rose-leaf; forest-leaf; forest-singleton; _-<_>-)
+open import Vatras.Framework.Variants using (Forest; _-<_>-)
 open import Vatras.Framework.Compiler using (LanguageCompiler)
 open import Vatras.Lang.ADT (Prop F) Forest as ADT using (ADT; ADTL; leaf; _⟨_,_⟩)
 open import Vatras.Lang.VT F as VT
@@ -24,76 +24,76 @@ open Merge.Prop F using (⊕-specₚ)
 
 open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_)
 
-module _ {A : 𝔸} where
-  -- artifact atom, artifact children, artifact neighbors
-  pushy : atoms A → ADT A → ADT A → ADT A
-  pushy a (leaf v)      (leaf v')     = leaf (a -< v >- ∷ v')
-  pushy a c@(leaf v)    (D ⟨ l , r ⟩) = D ⟨ pushy a c l , pushy a c r ⟩
-  pushy a (D ⟨ l , r ⟩) n             = D ⟨ pushy a l n , pushy a r n ⟩
+-- artifact atom, artifact children, artifact neighbors
+pushy : ∀ {A} → atoms A → ADT A → ADT A → ADT A
+pushy a (leaf v)      (leaf v')     = leaf (a -< v >- ∷ v')
+pushy a c@(leaf v)    (D ⟨ l , r ⟩) = D ⟨ pushy a c l , pushy a c r ⟩
+pushy a (D ⟨ l , r ⟩) n             = D ⟨ pushy a l n , pushy a r n ⟩
 
-  mutual
-    translate-both : (l r : List (UnrootedVT A)) → ADT A
-    translate-both l r = translate-all l ⊕ translate-all r
+mutual
+  translate-both : ∀ {A} → (l r : List (UnrootedVT A)) → ADT A
+  translate-both l r = translate-all l ⊕ translate-all r
 
-    translate-all : List (UnrootedVT A) → ADT A
-    translate-all []                               = leaf []
-    translate-all (a -< l >- ∷ xs)                 = pushy a (translate-all l) (translate-all xs)
-    translate-all (if[ p ]then[ l ] ∷ xs)          = p ⟨ translate-both l xs , translate-all xs ⟩
-    translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-both l xs , translate-both r xs ⟩
+  translate-all : ∀ {A} → List (UnrootedVT A) → ADT A
+  translate-all []                               = leaf []
+  translate-all (a -< l >- ∷ xs)                 = pushy a (translate-all l) (translate-all xs)
+  translate-all (if[ p ]then[ l ] ∷ xs)          = p ⟨ translate-both l xs , translate-all xs ⟩
+  translate-all (if[ p ]then[ l ]else[ r ] ∷ xs) = p ⟨ translate-both l xs , translate-both r xs ⟩
 
-  translate : VT A → ADT A
-  translate if-true[ xs ] = translate-all xs
+translate : ∀ {A} → VT A → ADT A
+translate if-true[ xs ] = translate-all xs
 
-  -- Preservation Proofs --
-  
-  -- formal specification of pushy: It should create an ADT such that for any configuration c, there is an artifact at the top of left
-  pushy-preserves : ∀ a l n c → ⟦ pushy a l n ⟧ₚ c ≡ a -< ⟦ l ⟧ₚ c >- ∷ ⟦ n ⟧ₚ c
-  pushy-preserves a (leaf v) (leaf v') c = refl
-  pushy-preserves a (D ⟨ l , r ⟩) n c with eval D c
-  ... | true  = pushy-preserves a l n c
-  ... | false = pushy-preserves a r n c
-  pushy-preserves a x@(leaf v) (D ⟨ l , r ⟩) c with eval D c
-  ... | true  = pushy-preserves a x l c
-  ... | false = pushy-preserves a x r c
+-- Preservation Proofs --
 
-  preserves-all : ∀ (vts : List (UnrootedVT A)) → flip configure-all vts ≗ ⟦ translate-all vts ⟧ₚ
-  preserves-all [] c = refl
-  preserves-all (a -< l >- ∷ xs) c =
-      flip configure-all (a -< l >- ∷ xs) c
-    ≡⟨⟩
-      a -< configure-all c l >- ∷ configure-all c xs
-    ≡⟨ cong (_ ∷_) (preserves-all xs c) ⟩
-      a -< configure-all c l >- ∷ ⟦ translate-all xs ⟧ₚ c
-    ≡⟨ cong (λ z → a -< z >- ∷ _) (preserves-all l c) ⟩
-      a -< ⟦ translate-all l ⟧ₚ c >- ∷ ⟦ translate-all xs ⟧ₚ c
-    ≡⟨ pushy-preserves a (translate-all l) (translate-all xs) c ⟨
-      ⟦ pushy a (translate-all l) (translate-all xs) ⟧ₚ c
-    ∎
-  preserves-all (if[ p ]then[ l ] ∷ xs) c with eval p c
-  ... | true  =
-      configure-all c l ++ configure-all c xs
-    ≡⟨ cong₂ _++_ (preserves-all l c) (preserves-all xs c) ⟩
-      ⟦ translate-all l ⟧ₚ c ++ ⟦ translate-all xs ⟧ₚ c
-    ≡⟨ ⊕-specₚ (translate-all l) (translate-all xs) c ⟨
-      ⟦ translate-all l ⊕ translate-all xs ⟧ₚ c
-    ≡⟨⟩
-      ⟦ translate-both l xs ⟧ₚ c
-    ∎
-  ... | false = preserves-all xs c
-  preserves-all (if[ p ]then[ l ]else[ r ] ∷ xs) c with eval p c -- the cases for the choice alternatives are analogous to the first option case above
-  ... | true
-    rewrite preserves-all l c
-          | preserves-all xs c
-          | ⊕-specₚ (translate-all l) (translate-all xs) c
-          = refl
-  ... | false
-    rewrite preserves-all r c
-          | preserves-all xs c
-          | ⊕-specₚ (translate-all r) (translate-all xs) c
-          = refl
+-- formal specification of pushy: It should create an ADT such that for any configuration c, there is an artifact at the top of left
+pushy-preserves : ∀ {A} (a : atoms A) (l n : ADT A) c
+  → ⟦ pushy a l n ⟧ₚ c ≡ a -< ⟦ l ⟧ₚ c >- ∷ ⟦ n ⟧ₚ c
+pushy-preserves a (leaf v) (leaf v') c = refl
+pushy-preserves a (D ⟨ l , r ⟩) n c with eval D c
+... | true  = pushy-preserves a l n c
+... | false = pushy-preserves a r n c
+pushy-preserves a x@(leaf v) (D ⟨ l , r ⟩) c with eval D c
+... | true  = pushy-preserves a x l c
+... | false = pushy-preserves a x r c
 
-  preserves : ∀ (vt : VT A) → ⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
-  preserves if-true[ xs ] c = preserves-all xs c
+preserves-all : ∀ {A} (vts : List (UnrootedVT A)) → flip configure-all vts ≗ ⟦ translate-all vts ⟧ₚ
+preserves-all [] c = refl
+preserves-all (a -< l >- ∷ xs) c =
+    flip configure-all (a -< l >- ∷ xs) c
+  ≡⟨⟩
+    a -< configure-all c l >- ∷ configure-all c xs
+  ≡⟨ cong (_ ∷_) (preserves-all xs c) ⟩
+    a -< configure-all c l >- ∷ ⟦ translate-all xs ⟧ₚ c
+  ≡⟨ cong (λ z → a -< z >- ∷ _) (preserves-all l c) ⟩
+    a -< ⟦ translate-all l ⟧ₚ c >- ∷ ⟦ translate-all xs ⟧ₚ c
+  ≡⟨ pushy-preserves a (translate-all l) (translate-all xs) c ⟨
+    ⟦ pushy a (translate-all l) (translate-all xs) ⟧ₚ c
+  ∎
+preserves-all (if[ p ]then[ l ] ∷ xs) c with eval p c
+... | true  =
+    configure-all c l ++ configure-all c xs
+  ≡⟨ cong₂ _++_ (preserves-all l c) (preserves-all xs c) ⟩
+    ⟦ translate-all l ⟧ₚ c ++ ⟦ translate-all xs ⟧ₚ c
+  ≡⟨ ⊕-specₚ (translate-all l) (translate-all xs) c ⟨
+    ⟦ translate-all l ⊕ translate-all xs ⟧ₚ c
+  ≡⟨⟩
+    ⟦ translate-both l xs ⟧ₚ c
+  ∎
+... | false = preserves-all xs c
+preserves-all (if[ p ]then[ l ]else[ r ] ∷ xs) c with eval p c -- the cases for the choice alternatives are analogous to the first option case above
+... | true
+  rewrite preserves-all l c
+        | preserves-all xs c
+        | ⊕-specₚ (translate-all l) (translate-all xs) c
+        = refl
+... | false
+  rewrite preserves-all r c
+        | preserves-all xs c
+        | ⊕-specₚ (translate-all r) (translate-all xs) c
+        = refl
+
+preserves : ∀ {A} (vt : VT A) → ⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
+preserves if-true[ xs ] c = preserves-all xs c
 
 VT→PropADT : LanguageCompiler VariationTreeVL PropADTL
 VT→PropADT = record
@@ -106,19 +106,21 @@ PropADT≽VT : PropADTL ≽ VariationTreeVL
 PropADT≽VT e = translate e , ≗→≅ (preserves e)
 
 module Test {A : 𝔸} where
+  open Vatras.Framework.Variants using (rose-leaf; forest-leaf; forest-singleton)
+
   module Forest (a b : atoms A) where
     vt : VT A
     vt =
       if-true[
         vt-leaf a ∷ vt-leaf b ∷ []
       ]
-  
+
     adt : ADT A
     adt = leaf (rose-leaf a ∷ rose-leaf b ∷ [])
-  
+
     tr : translate vt ≡ adt
     tr = refl
-  
+
     pres : VT.⟦ vt ⟧ ≗ ⟦ translate vt ⟧ₚ
     pres _ = refl
 
@@ -135,7 +137,7 @@ module Test {A : 𝔸} where
 
     adt : ADT A
     adt = X ⟨ leaf (forest-singleton a (forest-leaf b)) , leaf (forest-leaf a) ⟩
-  
+
     tr : translate vt ≡ adt
     tr = refl
 

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -29,6 +29,15 @@ open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Comp
 open import Vatras.Lang.VT (Indexed F)
 open import Vatras.Lang.VT.Encode (Indexed F)
 
+{-|
+This function encodes a non-empty list of forests into a rootless variation tree.
+This encoding produces n-1 choices where n is the number of forests to encode.
+
+Arguments:
+1. Next available index for new feature names.
+2. Head of list of forests to encode
+3. Tail of list of forests to encode
+-}
 translate' : ∀ {A} → ℕ → Forest A → List (Forest A) → List (UnrootedVT A)
 translate' n x []       = encode-forest x
 translate' n x (y ∷ ys) =
@@ -41,9 +50,21 @@ translate' n x (y ∷ ys) =
 translate : ∀ {A} → VariantList A → VT A
 translate (x ∷ xs) = if-true[ translate' zero x xs ]
 
+{-|
+A variation tree created by "translate" from a list l produces a forest
+from the list at index i when exactly the feature (f , i) is set to true.
+-}
 conf : ℕ → Configuration
 conf i (_ , j) = i ≡ᵇ j
 
+{-|
+From a configuration, we can compute the index of the produced variant in the initial list.
+To do so, we have to inspect the feature at each choice from 0 up to "max", where "max" is the
+index of the feature in the last choice.
+To prove termination, we start with index i = max (see fnoc) and decrease i step by step.
+To inspect the features in ascending order though, we hence have to inspect the configuration c at point "max - i" at each step.
+The "offset" value is needed for induction to specify at which point in a sublist we are currently at (i.e., how far we recursed).
+-}
 fnoci : (offset max i : ℕ) → Configuration → ℕ
 fnoci offset max zero c = max
 fnoci offset max (suc i) c =
@@ -54,6 +75,9 @@ fnoci offset max (suc i) c =
 fnoc : (max : ℕ) → Configuration → ℕ
 fnoc max = fnoci zero max max
 
+{-|
+The values for "max" and "offset" balance out.
+-}
 fnoci-invariant : ∀ {ℓ} {A : Set ℓ} (x : A) (xs : List⁺ A) (n m i : ℕ) (c : Configuration) →
     i ≤ m →
     find-or-last (fnoci (suc n)      m  i c) (     xs)

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -171,7 +171,7 @@ module Preservation (A : 𝔸) where
       VariantList.⟦ x ∷ xs ⟧ (fnoc (List⁺.length (x ∷ xs)) c)
     ∎
 
-VariantList→VT : LanguageCompiler VariantListL VariationTreeVL
+VariantList→VT : LanguageCompiler VariantListL VTL
 VariantList→VT = record
   { compile = translate
   ; config-compiler = λ e → record { to = conf ; from = fnoc (List⁺.length e) }
@@ -180,8 +180,8 @@ VariantList→VT = record
       preserves-⊆ e , preserves-⊇ e
   }
 
-VT≽VariantList : VariationTreeVL ≽ VariantListL
+VT≽VariantList : VTL ≽ VariantListL
 VT≽VariantList {A} e = translate e , ≅[]→≅ (LanguageCompiler.preserves VariantList→VT e)
 
-VT-is-Complete : Complete VariationTreeVL
+VT-is-Complete : Complete VTL
 VT-is-Complete = completeness-by-expressiveness (VariantList-is-Complete) VT≽VariantList

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -92,10 +92,10 @@ fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
 
 module Preservation (A : 𝔸) where
   translate'-preserves-conf : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (i : ℕ) →
-    configure-all (conf (i + n)) (translate' n x xs) ≡ VariantList.⟦ x ∷ xs ⟧ i
+    configure-all (translate' n x xs) (conf (i + n)) ≡ VariantList.⟦ x ∷ xs ⟧ i
   translate'-preserves-conf x [] n i =
     begin
-      configure-all (conf (i + n)) (encode-forest x)
+      configure-all (encode-forest x) (conf (i + n))
     ≡⟨ encode-idemp Forest A encoder (conf (i + n)) x ⟩
       x
     ≡⟨⟩
@@ -103,9 +103,9 @@ module Preservation (A : 𝔸) where
     ∎
   translate'-preserves-conf x (y ∷ ys) n zero rewrite ≡ᵇ-refl n =
     begin
-      configure-all (conf n) (encode-forest x) ++ []
+      configure-all (encode-forest x) (conf n) ++ []
     ≡⟨ ++-identityʳ _ ⟩
-      configure-all (conf n) (encode-forest x)
+      configure-all (encode-forest x) (conf n)
     ≡⟨ encode-idemp Forest A encoder (conf n) x ⟩
       x
     ≡⟨⟩
@@ -113,11 +113,11 @@ module Preservation (A : 𝔸) where
     ∎
   translate'-preserves-conf x (y ∷ ys) n (suc i) rewrite m+n≢ᵇn i n =
     begin
-      configure-all (conf (suc i + n)) (translate' (suc n) y ys) ++ []
+      configure-all (translate' (suc n) y ys) (conf (suc i + n)) ++ []
     ≡⟨ ++-identityʳ _ ⟩
-      configure-all (conf (suc i + n)) (translate' (suc n) y ys)
-    ≡⟨ cong (λ eq → configure-all (conf eq) (translate' (suc n) y ys)) (+-suc i n) ⟨
-      configure-all (conf (i + suc n)) (translate' (suc n) y ys)
+      configure-all (translate' (suc n) y ys) (conf (suc i + n))
+    ≡⟨ cong (λ eq → configure-all (translate' (suc n) y ys) (conf eq)) (+-suc i n) ⟨
+      configure-all (translate' (suc n) y ys) (conf (i + suc n))
     ≡⟨ translate'-preserves-conf y ys (suc n) i ⟩
       VariantList.⟦ y ∷ ys ⟧ i
     ≡⟨⟩
@@ -130,31 +130,31 @@ module Preservation (A : 𝔸) where
     begin
       VariantList.⟦ x ∷ xs ⟧ i
     ≡⟨ translate'-preserves-conf x xs zero i ⟨
-      configure-all (conf (i + zero)) (translate' zero x xs)
-    ≡⟨ cong (λ eq → configure-all (conf eq) (translate' zero x xs)) (+-identityʳ i) ⟩
-      configure-all (conf i) (translate' zero x xs)
+      configure-all (translate' zero x xs) (conf (i + zero))
+    ≡⟨ cong (λ eq → configure-all (translate' zero x xs) (conf eq)) (+-identityʳ i) ⟩
+      configure-all (translate' zero x xs) (conf i)
     ≡⟨⟩
       ⟦ translate (x ∷ xs) ⟧ (conf i)
     ∎
 
   translate'-preserves-fnoc : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (c : Configuration) →
-      configure-all c (translate' n x xs)
+      configure-all (translate' n x xs) c
     ≡ VariantList.⟦ x ∷ xs ⟧ (fnoci n (List⁺.length (x ∷ xs)) (List⁺.length (x ∷ xs)) c)
   translate'-preserves-fnoc x [] n c = encode-idemp Forest A encoder c x
   translate'-preserves-fnoc x (y ∷ ys) n c with c n in eq
   ... | true rewrite n∸n≡0 (List⁺.length (y ∷ ys)) | +-identityʳ n | eq =
     begin
-      configure-all c (encode-forest x) ++ []
+      configure-all (encode-forest x) c ++ []
     ≡⟨ ++-identityʳ _ ⟩
-      configure-all c (encode-forest x)
+      configure-all (encode-forest x) c
     ≡⟨ encode-idemp Forest A encoder c x ⟩
       x
     ∎
   ... | false rewrite n∸n≡0 (List⁺.length (y ∷ ys)) | +-identityʳ n | eq =
     begin
-      configure-all c (translate' (suc n) y ys) ++ []
+      configure-all (translate' (suc n) y ys) c ++ []
     ≡⟨ ++-identityʳ _ ⟩
-      configure-all c (translate' (suc n) y ys)
+      configure-all (translate' (suc n) y ys) c
     ≡⟨ translate'-preserves-fnoc y ys (suc n) c ⟩
       VariantList.⟦     y ∷ ys ⟧
         (fnoci (suc n) (List⁺.length (    y ∷ ys)) (List⁺.length (y ∷ ys)) c)
@@ -169,7 +169,7 @@ module Preservation (A : 𝔸) where
     begin
       ⟦ translate (x ∷ xs) ⟧ c
     ≡⟨⟩
-      configure-all c (translate' zero x xs)
+      configure-all (translate' zero x xs) c
     ≡⟨ translate'-preserves-fnoc x xs zero c ⟩
       VariantList.⟦ x ∷ xs ⟧ (fnoc (List⁺.length (x ∷ xs)) c)
     ∎

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -13,16 +13,13 @@ open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; sym;
 open Eq.≡-Reasoning
 open import Function using (_$_)
 
--- TODO: Move to separate module or reuse indexeddimension
-Numbered : Set → Set
-Numbered F = F × ℕ
-
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp)
+open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
 
 open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; VariantListL)
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)
-open import Vatras.Lang.VT (Numbered F)
-open import Vatras.Lang.VT.Encode (Numbered F)
+open import Vatras.Lang.VT (Indexed F)
+open import Vatras.Lang.VT.Encode (Indexed F)
 
 open import Vatras.Data.Prop using (var)
 open import Vatras.Data.EqIndexedSet

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -3,10 +3,10 @@ open import Vatras.Framework.Definitions using (𝔽; 𝔸)
 module Vatras.Translation.Lang.VariantList-to-VT (F : 𝔽) (f : F) where
 
 open import Data.Bool as Bool using (if_then_else_; true; false)
-open import Data.List as List using (List; []; _∷_; _++_)
+open import Data.List using (List; []; _∷_; _++_)
 open import Data.List.Properties using (++-identityʳ)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_; _∷⁺_)
-open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_; _+_; _≤_; _<_; s≤s; z≤n; _∸_)
+open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_; _+_; _≤_; s≤s; z≤n; _∸_)
 open import Data.Nat.Properties using (+-suc; +-identityʳ; ≤-refl; n∸n≡0)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; sym; cong)
@@ -17,12 +17,12 @@ open import Vatras.Data.EqIndexedSet
 open import Vatras.Util.List using (find-or-last)
 open import Vatras.Util.AuxProofs using (∸-suc; ≤-suc; ≡ᵇ-refl; m+n≢ᵇn)
 
-open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp)
+open import Vatras.Framework.Variants using (Forest; encode-idemp)
 open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
 open import Vatras.Framework.Compiler using (LanguageCompiler)
 open import Vatras.Framework.Proof.ForFree Forest using (completeness-by-expressiveness)
 open import Vatras.Framework.Properties.Completeness Forest using (Complete)
-open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_)
+open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_; expressiveness-from-compiler)
 
 open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; VariantListL)
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -1,5 +1,5 @@
 open import Vatras.Framework.Definitions using (𝔽; 𝔸)
--- We assume the existence of at least one atom
+-- We assume the existence of at least one atom.
 module Vatras.Translation.Lang.VariantList-to-VT (F : 𝔽) (f : F) where
 
 open import Data.Bool as Bool using (if_then_else_; true; false)
@@ -7,27 +7,26 @@ open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatM
 open import Data.List.Properties using (++-identityʳ)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_; _∷⁺_)
 open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_; _+_; _≤_; _<_; s≤s; z≤n; _∸_)
-open import Data.Nat.Properties using (+-suc; +-identityʳ; m≤n+m; ≤-refl; m≤n⇒m≤n+o; ≡⇒≡ᵇ; n∸n≡0; +-comm)
-open import Data.Product using (_×_; _,_)
+open import Data.Nat.Properties using (+-suc; +-identityʳ; m≤n+m; ≤-refl; ≡⇒≡ᵇ; n∸n≡0)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; sym; cong)
 open Eq.≡-Reasoning
-open import Function using (_$_)
+
+open import Vatras.Data.Prop using (var)
+open import Vatras.Data.EqIndexedSet
+open import Vatras.Util.List using (find-or-last)
 
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp)
 open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
+open import Vatras.Framework.Compiler using (LanguageCompiler)
+open import Vatras.Framework.Proof.ForFree Forest using (completeness-by-expressiveness)
+open import Vatras.Framework.Properties.Completeness Forest using (Complete)
+open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_)
 
 open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; VariantListL)
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)
 open import Vatras.Lang.VT (Indexed F)
 open import Vatras.Lang.VT.Encode (Indexed F)
-
-open import Vatras.Data.Prop using (var)
-open import Vatras.Data.EqIndexedSet
-open import Vatras.Framework.Compiler using (LanguageCompiler)
-open import Vatras.Framework.Properties.Completeness Forest using (Complete)
-open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_)
-open import Vatras.Framework.Proof.ForFree Forest using (completeness-by-expressiveness)
-open import Vatras.Util.List using (find-or-last)
 
 -- TODO: contribute these functions to stl, and temporarily move them to utilities
 module TODO_STL where
@@ -124,15 +123,15 @@ module Preservation (A : 𝔸) where
 
   preserves-⊆ : ∀ (l : VariantList A)
     → VariantList.⟦ l ⟧ ⊆[ conf ] ⟦ translate l ⟧
-  preserves-⊆ (x ∷ xs) i = sym $
+  preserves-⊆ (x ∷ xs) i =
     begin
-      ⟦ translate (x ∷ xs) ⟧ (conf i)
-    ≡⟨⟩
-      configure-all (conf i) (translate' zero x xs)
-    ≡⟨ cong (λ eq → configure-all (conf eq) (translate' zero x xs)) (+-identityʳ i) ⟨
-      configure-all (conf (i + zero)) (translate' zero x xs)
-    ≡⟨ translate'-preserves-conf x xs zero i ⟩
       VariantList.⟦ x ∷ xs ⟧ i
+    ≡⟨ translate'-preserves-conf x xs zero i ⟨
+      configure-all (conf (i + zero)) (translate' zero x xs)
+    ≡⟨ cong (λ eq → configure-all (conf eq) (translate' zero x xs)) (+-identityʳ i) ⟩
+      configure-all (conf i) (translate' zero x xs)
+    ≡⟨⟩
+      ⟦ translate (x ∷ xs) ⟧ (conf i)
     ∎
 
   translate'-preserves-fnoc : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (c : Conf) →

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -1,6 +1,6 @@
 open import Vatras.Framework.Definitions using (𝔽; 𝔸)
 -- We assume the existence of at least one atom.
-module Vatras.Translation.Lang.VariantList-to-VT (F : 𝔽) (f : F) where
+module Vatras.Translation.Lang.VariantList-to-VT where
 
 open import Data.Bool as Bool using (if_then_else_; true; false)
 open import Data.List using (List; []; _∷_; _++_)
@@ -26,8 +26,8 @@ open import Vatras.Framework.Relation.Expressiveness Forest using (_≽_; expres
 
 open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; VariantListL)
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)
-open import Vatras.Lang.VT (Indexed F)
-open import Vatras.Lang.VT.Encode (Indexed F)
+open import Vatras.Lang.VT ℕ
+open import Vatras.Lang.VT.Encode ℕ
 
 {-|
 This function encodes a non-empty list of forests into a rootless variation tree.
@@ -41,7 +41,7 @@ Arguments:
 translate' : ∀ {A} → ℕ → Forest A → List (Forest A) → List (UnrootedVT A)
 translate' n x []       = encode-forest x
 translate' n x (y ∷ ys) =
-  if[ var (f , n) ]then[
+  if[ var n ]then[
     encode-forest x
   ]else[
     translate' (suc n) y ys
@@ -52,10 +52,10 @@ translate (x ∷ xs) = if-true[ translate' zero x xs ]
 
 {-|
 A variation tree created by "translate" from a list l produces a forest
-from the list at index i when exactly the feature (f , i) is set to true.
+from the list at index i when exactly the feature i is set to true.
 -}
 conf : ℕ → Configuration
-conf i (_ , j) = i ≡ᵇ j
+conf = _≡ᵇ_
 
 {-|
 From a configuration, we can compute the index of the produced variant in the initial list.
@@ -68,7 +68,7 @@ The "offset" value is needed for induction to specify at which point in a sublis
 fnoci : (offset max i : ℕ) → Configuration → ℕ
 fnoci offset max zero c = max
 fnoci offset max (suc i) c =
-  if c (f , offset + (max ∸ suc i))
+  if c (offset + (max ∸ suc i))
   then max ∸ suc i
   else fnoci offset max i c
 
@@ -86,7 +86,7 @@ fnoci-invariant x xs n m zero c z≤n = refl
 fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
   rewrite +-∸-assoc 1 i≤m
         | sym (+-suc n (m ∸ i))
-        with c (f , n + suc (m ∸ i))
+        with c (n + suc (m ∸ i))
 ... | true  = refl
 ... | false = fnoci-invariant x xs n (suc m) i c (m≤n⇒m≤1+n i≤m)
 
@@ -141,7 +141,7 @@ module Preservation (A : 𝔸) where
       configure-all c (translate' n x xs)
     ≡ VariantList.⟦ x ∷ xs ⟧ (fnoci n (List⁺.length (x ∷ xs)) (List⁺.length (x ∷ xs)) c)
   translate'-preserves-fnoc x [] n c = encode-idemp Forest A encoder c x
-  translate'-preserves-fnoc x (y ∷ ys) n c with c (f , n) in eq
+  translate'-preserves-fnoc x (y ∷ ys) n c with c n in eq
   ... | true rewrite n∸n≡0 (List⁺.length (y ∷ ys)) | +-identityʳ n | eq =
     begin
       configure-all c (encode-forest x) ++ []

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -62,20 +62,20 @@ translate' n x (y ∷ ys) =
 translate : ∀ {A} → VariantList A → VT A
 translate (x ∷ xs) = if-true[ translate' zero x xs ]
 
-conf : ℕ → Conf
+conf : ℕ → Configuration
 conf i (_ , j) = i ≡ᵇ j
 
-fnoci : (offset max i : ℕ) → Conf → ℕ
+fnoci : (offset max i : ℕ) → Configuration → ℕ
 fnoci offset max zero c = max
 fnoci offset max (suc i) c =
   if c (f , offset + (max ∸ suc i))
   then max ∸ suc i
   else fnoci offset max i c
 
-fnoc : (max : ℕ) → Conf → ℕ
+fnoc : (max : ℕ) → Configuration → ℕ
 fnoc max = fnoci zero max max
 
-fnoci-invariant : ∀ {ℓ} {A : Set ℓ} (x : A) (xs : List⁺ A) (n m i : ℕ) (c : Conf) →
+fnoci-invariant : ∀ {ℓ} {A : Set ℓ} (x : A) (xs : List⁺ A) (n m i : ℕ) (c : Configuration) →
     i ≤ m →
     find-or-last (fnoci (suc n)      m  i c) (     xs)
   ≡ find-or-last (fnoci      n  (suc m) i c) (x ∷⁺ xs)
@@ -134,7 +134,7 @@ module Preservation (A : 𝔸) where
       ⟦ translate (x ∷ xs) ⟧ (conf i)
     ∎
 
-  translate'-preserves-fnoc : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (c : Conf) →
+  translate'-preserves-fnoc : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (c : Configuration) →
       configure-all c (translate' n x xs)
     ≡ VariantList.⟦ x ∷ xs ⟧ (fnoci n (List⁺.length (x ∷ xs)) (List⁺.length (x ∷ xs)) c)
   translate'-preserves-fnoc x [] n c = encode-idemp Forest A encoder c x

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -92,7 +92,7 @@ fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
 
 module Preservation (A : 𝔸) where
   translate'-preserves-conf : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (i : ℕ) →
-    configure-all (conf (i + n)) (translate' n x xs ) ≡ VariantList.⟦ x ∷ xs ⟧ i
+    configure-all (conf (i + n)) (translate' n x xs) ≡ VariantList.⟦ x ∷ xs ⟧ i
   translate'-preserves-conf x [] n i =
     begin
       configure-all (conf (i + n)) (encode-forest x)
@@ -187,4 +187,4 @@ VT≽VariantList : VTL ≽ VariantListL
 VT≽VariantList = expressiveness-from-compiler VariantList→VT
 
 VT-is-complete : Complete VTL
-VT-is-complete = completeness-by-expressiveness (VariantList-is-Complete) VT≽VariantList
+VT-is-complete = completeness-by-expressiveness VariantList-is-Complete VT≽VariantList

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -3,11 +3,11 @@ open import Vatras.Framework.Definitions using (𝔽; 𝔸)
 module Vatras.Translation.Lang.VariantList-to-VT (F : 𝔽) (f : F) where
 
 open import Data.Bool as Bool using (if_then_else_; true; false)
-open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
+open import Data.List as List using (List; []; _∷_; _++_)
 open import Data.List.Properties using (++-identityʳ)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_; _∷⁺_)
 open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_; _+_; _≤_; _<_; s≤s; z≤n; _∸_)
-open import Data.Nat.Properties using (+-suc; +-identityʳ; m≤n+m; ≤-refl; ≡⇒≡ᵇ; n∸n≡0)
+open import Data.Nat.Properties using (+-suc; +-identityʳ; ≤-refl; n∸n≡0)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; sym; cong)
 open Eq.≡-Reasoning
@@ -15,6 +15,7 @@ open Eq.≡-Reasoning
 open import Vatras.Data.Prop using (var)
 open import Vatras.Data.EqIndexedSet
 open import Vatras.Util.List using (find-or-last)
+open import Vatras.Util.AuxProofs using (∸-suc; ≤-sucʳ; ≡ᵇ-refl; m+n≢ᵇn)
 
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp)
 open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
@@ -27,28 +28,6 @@ open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; Va
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)
 open import Vatras.Lang.VT (Indexed F)
 open import Vatras.Lang.VT.Encode (Indexed F)
-
--- TODO: contribute these functions to stl, and temporarily move them to utilities
-module TODO_STL where
-  ∸-suc : ∀ n m → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-  ∸-suc n         .zero       z≤n = refl
-  ∸-suc (suc n) (suc m) (s≤s n≤m) = ∸-suc n m n≤m
-
-  ≤-sucʳ : ∀ {m n} → m ≤ n → m ≤ suc n
-  ≤-sucʳ z≤n       = z≤n
-  ≤-sucʳ (s≤s leq) = s≤s (≤-sucʳ leq)
-
-  ≡ᵇ-refl : ∀ n → (n ≡ᵇ n) ≡ true
-  ≡ᵇ-refl zero    = refl
-  ≡ᵇ-refl (suc n) = ≡ᵇ-refl n
-
-  ≡ᵇ-< : ∀ {m n} → n < m → (m ≡ᵇ n) ≡ false
-  ≡ᵇ-< {.(suc _)} {zero}  (s≤s _) = refl
-  ≡ᵇ-< {suc m}    {suc n} (s≤s x) = ≡ᵇ-< x
-
-  m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
-  m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
-open TODO_STL
 
 translate' : ∀ {A} → ℕ → Forest A → List (Forest A) → List (UnrootedVT A)
 translate' n x []       = encode-forest x

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -7,7 +7,7 @@ open import Data.List using (List; []; _∷_; _++_)
 open import Data.List.Properties using (++-identityʳ)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_; _∷⁺_)
 open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_; _+_; _≤_; s≤s; z≤n; _∸_)
-open import Data.Nat.Properties using (+-suc; +-identityʳ; ≤-refl; n∸n≡0)
+open import Data.Nat.Properties using (+-suc; +-identityʳ; ≤-refl; n∸n≡0; m≤n⇒m≤1+n; +-∸-assoc)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl; sym; cong)
 open Eq.≡-Reasoning
@@ -15,7 +15,7 @@ open Eq.≡-Reasoning
 open import Vatras.Data.Prop using (var)
 open import Vatras.Data.EqIndexedSet
 open import Vatras.Util.List using (find-or-last)
-open import Vatras.Util.AuxProofs using (∸-suc; ≤-suc; ≡ᵇ-refl; m+n≢ᵇn)
+open import Vatras.Util.AuxProofs using (≡ᵇ-refl; m+n≢ᵇn)
 
 open import Vatras.Framework.Variants using (Forest; encode-idemp)
 open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
@@ -84,11 +84,11 @@ fnoci-invariant : ∀ {ℓ} {A : Set ℓ} (x : A) (xs : List⁺ A) (n m i : ℕ)
   ≡ find-or-last (fnoci      n  (suc m) i c) (x ∷⁺ xs)
 fnoci-invariant x xs n m zero c z≤n = refl
 fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
-  rewrite ∸-suc i≤m
+  rewrite +-∸-assoc 1 i≤m
         | sym (+-suc n (m ∸ i))
         with c (f , n + suc (m ∸ i))
 ... | true  = refl
-... | false = fnoci-invariant x xs n (suc m) i c (≤-suc i≤m)
+... | false = fnoci-invariant x xs n (suc m) i c (m≤n⇒m≤1+n i≤m)
 
 module Preservation (A : 𝔸) where
   translate'-preserves-conf : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (i : ℕ) →

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -184,7 +184,7 @@ VariantList→VT = record
   }
 
 VT≽VariantList : VTL ≽ VariantListL
-VT≽VariantList {A} e = translate e , ≅[]→≅ (LanguageCompiler.preserves VariantList→VT e)
+VT≽VariantList = expressiveness-from-compiler VariantList→VT
 
 VT-is-complete : Complete VTL
 VT-is-complete = completeness-by-expressiveness (VariantList-is-Complete) VT≽VariantList

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -15,7 +15,7 @@ open Eq.≡-Reasoning
 open import Vatras.Data.Prop using (var)
 open import Vatras.Data.EqIndexedSet
 open import Vatras.Util.List using (find-or-last)
-open import Vatras.Util.AuxProofs using (∸-suc; ≤-sucʳ; ≡ᵇ-refl; m+n≢ᵇn)
+open import Vatras.Util.AuxProofs using (∸-suc; ≤-suc; ≡ᵇ-refl; m+n≢ᵇn)
 
 open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp)
 open import Vatras.Framework.Annotation.IndexedDimension using (Indexed)
@@ -64,7 +64,7 @@ fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
         | sym (+-suc n (m ∸ i))
         with c (f , n + suc (m ∸ i))
 ... | true  = refl
-... | false = fnoci-invariant x xs n (suc m) i c (≤-sucʳ i≤m)
+... | false = fnoci-invariant x xs n (suc m) i c (≤-suc i≤m)
 
 module Preservation (A : 𝔸) where
   translate'-preserves-conf : ∀ (x : Forest A) (xs : List (Forest A)) (n : ℕ) (i : ℕ) →

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -60,7 +60,7 @@ fnoci-invariant : ∀ {ℓ} {A : Set ℓ} (x : A) (xs : List⁺ A) (n m i : ℕ)
   ≡ find-or-last (fnoci      n  (suc m) i c) (x ∷⁺ xs)
 fnoci-invariant x xs n m zero c z≤n = refl
 fnoci-invariant x xs n (suc m) (suc i) c (s≤s i≤m)
-  rewrite ∸-suc m i i≤m
+  rewrite ∸-suc i≤m
         | sym (+-suc n (m ∸ i))
         with c (f , n + suc (m ∸ i))
 ... | true  = refl

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -1,6 +1,6 @@
 open import Vatras.Framework.Definitions using (𝔽; 𝔸)
 -- We assume the existence of at least one atom
-module Vatras.Translation.Lang.VariantList-to-VariationTree (F : 𝔽) (f : F) where
+module Vatras.Translation.Lang.VariantList-to-VT (F : 𝔽) (f : F) where
 
 open import Data.Bool as Bool using (if_then_else_; true; false)
 open import Data.List as List using (List; []; _∷_; _++_; map; concat; concatMap)
@@ -21,8 +21,8 @@ open import Vatras.Framework.Variants using (Forest; Variant-is-VL; encode-idemp
 
 open import Vatras.Lang.VariantList Forest as VariantList using (VariantList; VariantListL)
 open import Vatras.Lang.VariantList.Properties Forest using (VariantList-is-Complete)
-open import Vatras.Lang.VariationTree (Numbered F)
-open import Vatras.Lang.VariationTree.Encode (Numbered F)
+open import Vatras.Lang.VT (Numbered F)
+open import Vatras.Lang.VT.Encode (Numbered F)
 
 open import Vatras.Data.Prop using (var)
 open import Vatras.Data.EqIndexedSet

--- a/src/Vatras/Translation/Lang/VariantList-to-VT.agda
+++ b/src/Vatras/Translation/Lang/VariantList-to-VT.agda
@@ -183,5 +183,5 @@ VariantList→VT = record
 VT≽VariantList : VTL ≽ VariantListL
 VT≽VariantList {A} e = translate e , ≅[]→≅ (LanguageCompiler.preserves VariantList→VT e)
 
-VT-is-Complete : Complete VTL
-VT-is-Complete = completeness-by-expressiveness (VariantList-is-Complete) VT≽VariantList
+VT-is-complete : Complete VTL
+VT-is-complete = completeness-by-expressiveness (VariantList-is-Complete) VT≽VariantList

--- a/src/Vatras/Translation/LanguageMap.lagda.md
+++ b/src/Vatras/Translation/LanguageMap.lagda.md
@@ -21,19 +21,27 @@ open import Relation.Binary using (DecidableEquality)
 open import Relation.Binary.PropositionalEquality as Eq using (_≢_; _≗_)
 open import Relation.Nullary.Negation using (¬_)
 
-open import Vatras.Framework.Variants using (Rose; Variant-is-VL)
+open import Vatras.Framework.Variants using (Rose; Forest; Variant-is-VL)
 Variant = Rose ∞
 
 open import Vatras.Framework.Annotation.IndexedDimension
 open import Vatras.Framework.Compiler
 open import Vatras.Framework.Definitions using (𝕍; 𝔽)
 open import Vatras.Framework.Relation.Expressiveness Variant using (_≽_; ≽-trans; _≻_; _⋡_; _≋_; compiler-cannot-exist)
-open import Vatras.Framework.Proof.ForFree Variant using (less-expressive-from-completeness; completeness-by-expressiveness; soundness-by-expressiveness)
-open import Vatras.Framework.Properties.Completeness Variant using (Complete)
-open import Vatras.Framework.Properties.Soundness Variant using (Sound)
 open import Vatras.Util.Nat.AtLeast as ℕ≥ using (ℕ≥; sucs)
 open import Vatras.Util.AuxProofs using (decidableEquality-×)
 open import Vatras.Util.String using (diagonal-ℕ; diagonal-ℕ⁻¹; diagonal-ℕ-proof)
+
+import Vatras.Framework.Proof.ForFree
+open Vatras.Framework.Proof.ForFree Variant using (less-expressive-from-completeness; completeness-by-expressiveness; soundness-by-expressiveness)
+open Vatras.Framework.Proof.ForFree using () renaming (soundness-by-expressiveness to soundness-by-expressiveness-on)
+
+import Vatras.Framework.Properties.Completeness
+import Vatras.Framework.Properties.Soundness
+open Vatras.Framework.Properties.Completeness Variant using (Complete)
+open Vatras.Framework.Properties.Soundness Variant using (Sound)
+open Vatras.Framework.Properties.Completeness using () renaming (Complete to Complete-on)
+open Vatras.Framework.Properties.Soundness using () renaming (Sound to Sound-on)
 
 open import Vatras.Lang.All
 open VariantList using (VariantListL)
@@ -44,6 +52,7 @@ open NADT using (NADTL)
 open ADT using (ADTL)
 open OC using (WFOCL)
 open FST using (FSTL)
+open VT using (VTL)
 
 open import Vatras.Lang.CCC.Encode using () renaming (encoder to CCC-Rose-encoder)
 open import Vatras.Translation.Lang.NCC.Rename using (NCC-rename≽NCC)
@@ -69,6 +78,8 @@ import Vatras.Translation.Lang.OC-to-2CC as OC-to-2CC
 import Vatras.Translation.Lang.OC-to-FST as OC-to-FST
 import Vatras.Translation.Lang.FST-to-OC as FST-to-OC
 import Vatras.Translation.Lang.FST-to-VariantList as FST-to-VariantList
+import Vatras.Translation.Lang.VariantList-to-VT as VariantList-to-VT
+import Vatras.Translation.Lang.VT-to-ADT as VT-to-ADT
 ```
 
 
@@ -347,4 +358,22 @@ OC-is-sound {F} _==_ = soundness-by-expressiveness (2CC-is-sound _==_) (OC-to-2C
 
 FST-is-sound : ∀ {F : 𝔽} (_==_ : DecidableEquality F) → Sound (FSTL F)
 FST-is-sound {F} _==_ = soundness-by-expressiveness VariantList-is-Sound (FST-to-VariantList.VariantList≽FST F _==_)
+```
+
+Variation Trees assume variants to be forests of rose trees.
+We hence cannot directly integrate it into the circle of compilers above.
+Yet, variant lists and ADTs are generic in their type of variants and hence can also denote forests.
+```agda
+open import Vatras.Lang.VariantList.Properties
+  using ()
+  renaming (VariantList-is-Sound to VariantList-is-sound-on; VariantList-is-Complete to VariantList-is-complete-on)
+
+ADT-is-sound-on : ∀ {F : 𝔽} (V : 𝕍) (_==_ : DecidableEquality F) → Sound-on V (ADTL F V)
+ADT-is-sound-on {F} V _==_ = soundness-by-expressiveness-on V (VariantList-is-sound-on V) (ADT-to-VariantList.VariantList≽ADT F V _==_)
+
+VT-is-complete : ∀ (F : 𝔽) (f : F) → Complete-on Forest (VTL (Indexed F))
+VT-is-complete F f = VariantList-to-VT.VT-is-complete F f
+
+VT-is-sound : ∀ {F : 𝔽} (_==_ : DecidableEquality F) → Sound-on Forest (VTL F)
+VT-is-sound {F} _==_ = soundness-by-expressiveness-on Forest (ADT-is-sound-on Forest _==_) (VT-to-ADT.ADT≽VT F)
 ```

--- a/src/Vatras/Translation/LanguageMap.lagda.md
+++ b/src/Vatras/Translation/LanguageMap.lagda.md
@@ -257,7 +257,7 @@ module Expressiveness-String = Expressiveness diagonal-ℕ diagonal-ℕ⁻¹ dia
 module Completeness {F : 𝔽} (f : F × ℕ → F) (f⁻¹ : F → F × ℕ) (f⁻¹∘f≗id : f⁻¹ ∘ f ≗ id) (D : F) where
   open Expressiveness f f⁻¹ f⁻¹∘f≗id
 
-  open import Vatras.Lang.VariantList.Properties {Variant} using (VariantList-is-Complete) public
+  open import Vatras.Lang.VariantList.Properties Variant using (VariantList-is-Complete) public
 
   CCC-is-complete : Complete (CCCL F)
   CCC-is-complete = completeness-by-expressiveness VariantList-is-Complete (CCC≽VariantList D)
@@ -325,7 +325,7 @@ module Completeness-String = Completeness diagonal-ℕ diagonal-ℕ⁻¹ diagona
 ```
 
 ```agda
-open import Vatras.Lang.VariantList.Properties {Variant} using (VariantList-is-Sound) public
+open import Vatras.Lang.VariantList.Properties Variant using (VariantList-is-Sound) public
 
 ADT-is-sound : ∀ {F : 𝔽} (_==_ : DecidableEquality F) → Sound (ADTL F Variant)
 ADT-is-sound {F} _==_ = soundness-by-expressiveness VariantList-is-Sound (ADT-to-VariantList.VariantList≽ADT F Variant _==_)

--- a/src/Vatras/Translation/LanguageMap.lagda.md
+++ b/src/Vatras/Translation/LanguageMap.lagda.md
@@ -371,8 +371,8 @@ open import Vatras.Lang.VariantList.Properties
 ADT-is-sound-on : ∀ {F : 𝔽} (V : 𝕍) (_==_ : DecidableEquality F) → Sound-on V (ADTL F V)
 ADT-is-sound-on {F} V _==_ = soundness-by-expressiveness-on V (VariantList-is-sound-on V) (ADT-to-VariantList.VariantList≽ADT F V _==_)
 
-VT-is-complete : ∀ (F : 𝔽) (f : F) → Complete-on Forest (VTL (Indexed F))
-VT-is-complete F f = VariantList-to-VT.VT-is-complete F f
+VT-is-complete : Complete-on Forest (VTL ℕ)
+VT-is-complete = VariantList-to-VT.VT-is-complete
 
 VT-is-sound : ∀ {F : 𝔽} (_==_ : DecidableEquality F) → Sound-on Forest (VTL F)
 VT-is-sound {F} _==_ = soundness-by-expressiveness-on Forest (ADT-is-sound-on Forest _==_) (VT-to-ADT.ADT≽VT F)

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -70,6 +70,7 @@ n∸1+m<n∸m {suc n} {zero} (s≤s m<n) = n<1+n n
 n∸1+m<n∸m {suc n} {suc m} (s≤s m<n) = n∸1+m<n∸m m<n
 
 ----- Properties of if_then_else
+-- TODO: Contribute to STL
 
 if-idemp : ∀ {ℓ} {A : Set ℓ} {a : A}
   → (c : Bool)

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -101,6 +101,22 @@ if-∧ : ∀ {ℓ} {A : Set ℓ} (x y : Bool) (a b : A)
 if-∧ false _ _ _ = refl
 if-∧ true  _ _ _ = refl
 
+if-congˡ : ∀ {ℓ} {A : Set ℓ} {a b c : A} x
+  → a ≡ c
+  → (if x then a else b) ≡ (if x then c else b)
+if-congˡ _ refl = refl
+
+if-congʳ : ∀ {ℓ} {A : Set ℓ} {a b d : A} x
+  → b ≡ d
+  → (if x then a else b) ≡ (if x then a else d)
+if-congʳ _ refl = refl
+
+if-cong : ∀ {ℓ} {A : Set ℓ} {a b c d : A} x
+  → a ≡ c
+  → b ≡ d
+  → (if x then a else b) ≡ (if x then c else d)
+if-cong _ refl refl = refl
+
 ----- Properties of Vectors
 
 module Vec where

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -6,7 +6,7 @@ open import Function using (id; _∘_)
 open import Data.Bool using (Bool; false; true; if_then_else_; not; _∧_)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.Nat using (ℕ; zero; suc; NonZero; _≡ᵇ_; _⊓_; _+_; _∸_; _<_; _≤_; s≤s; z≤n)
-open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0; m≤n+m)
+open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0; m≤n+m; +-∸-assoc)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.List.Properties using (length-++)
 open import Data.Product using (_×_; _,_)
@@ -39,14 +39,6 @@ true≢false refl ()
 m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
 m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
 
-∸-suc : ∀ {n m} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-∸-suc z≤n = refl
-∸-suc (s≤s n≤m) = ∸-suc n≤m
-
-≤-suc : ∀ {m n} → m ≤ n → m ≤ suc n
-≤-suc z≤n       = z≤n
-≤-suc (s≤s leq) = s≤s (≤-suc leq)
-
 n<m→m≡ᵇn : ∀ {n m : ℕ} → n < m → (m ≡ᵇ n) ≡ false
 n<m→m≡ᵇn {zero} (s≤s n<m) = refl
 n<m→m≡ᵇn {suc n} (s≤s n<m) = n<m→m≡ᵇn n<m
@@ -57,7 +49,7 @@ n<m→m≡ᵇn {suc n} (s≤s n<m) = n<m→m≡ᵇn n<m
     suc (suc m-1 ∸ suc n)
   ≡⟨ Eq.cong suc refl ⟩
     suc (m-1 ∸ n)
-  ≡⟨ ∸-suc n<m-1 ⟨
+  ≡⟨ +-∸-assoc 1 n<m-1 ⟨
     suc m-1 ∸ n
   ∎
 

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -51,29 +51,13 @@ n<m→m≡ᵇn : ∀ {n m : ℕ} → n < m → (m ≡ᵇ n) ≡ false
 n<m→m≡ᵇn {zero} (s≤s n<m) = refl
 n<m→m≡ᵇn {suc n} (s≤s n<m) = n<m→m≡ᵇn n<m
 
-1+[m-n]=[1+m]-n : ∀ (m n : ℕ) → (n ≤ m) → suc (m ∸ n) ≡ suc m ∸ n
-1+[m-n]=[1+m]-n m n n≤m =
-  begin
-    suc (m ∸ n)
-  ≡⟨⟩
-    1 + (m ∸ n)
-  ≡⟨ +-comm 1 (m ∸ n) ⟩
-    (m ∸ n) + 1
-  ≡⟨ Eq.sym (+-∸-comm 1 n≤m ) ⟩
-    (m + 1) ∸ n
-  ≡⟨ Eq.cong (_∸ n) (+-comm m 1) ⟩
-    (1 + m) ∸ n
-  ≡⟨⟩
-    suc m ∸ n
-  ∎
-
 1+[m-[1+n]]=m-n : ∀ (m n : ℕ) → (n < m) → suc (m ∸ suc n) ≡ m ∸ n
 1+[m-[1+n]]=m-n (suc m-1) n (s≤s n<m-1) =
   begin
     suc (suc m-1 ∸ suc n)
   ≡⟨ Eq.cong suc refl ⟩
     suc (m-1 ∸ n)
-  ≡⟨ 1+[m-n]=[1+m]-n m-1 n n<m-1 ⟩
+  ≡⟨ ∸-suc n<m-1 ⟨
     suc m-1 ∸ n
   ∎
 

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -39,6 +39,9 @@ true≢false refl ()
 m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
 m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
 
+≤-suc : ∀ {m n} → m ≤ n → m ≤ suc n
+≤-suc z≤n       = z≤n
+≤-suc (s≤s leq) = s≤s (≤-suc leq)
 
 n<m→m≡ᵇn : ∀ {n m : ℕ} → n < m → (m ≡ᵇ n) ≡ false
 n<m→m≡ᵇn {zero} (s≤s n<m) = refl
@@ -77,10 +80,6 @@ n∸1+m<n∸m {suc n} {suc m} (s≤s m<n) = n∸1+m<n∸m m<n
 ∸-suc : ∀ n m → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
 ∸-suc n         .zero       z≤n = refl
 ∸-suc (suc n) (suc m) (s≤s n≤m) = ∸-suc n m n≤m
-
-≤-sucʳ : ∀ {m n} → m ≤ n → m ≤ suc n
-≤-sucʳ z≤n       = z≤n
-≤-sucʳ (s≤s leq) = s≤s (≤-sucʳ leq)
 
 ----- Properties of if_then_else
 -- TODO: Contribute to STL

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -39,9 +39,6 @@ true≢false refl ()
 m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
 m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
 
-<-cong-+ˡ : ∀ {m n} (a : ℕ) → m < n → a + m < a + n
-<-cong-+ˡ zero x = x
-<-cong-+ˡ (suc a) x = s≤s (<-cong-+ˡ a x)
 
 n<m→m≡ᵇn : ∀ {n m : ℕ} → n < m → (m ≡ᵇ n) ≡ false
 n<m→m≡ᵇn {zero} (s≤s n<m) = refl

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -66,7 +66,7 @@ n∸1+m<n∸m {suc n} {zero} (s≤s m<n) = n<1+n n
 n∸1+m<n∸m {suc n} {suc m} (s≤s m<n) = n∸1+m<n∸m m<n
 
 ----- Properties of if_then_else
--- TODO: Contribute to STL
+-- TODO: These are contributed to STL now. Update our STL dependency and replace these by their STL counterpart.
 
 if-idemp : ∀ {ℓ} {A : Set ℓ} {a : A}
   → (c : Bool)

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -3,7 +3,7 @@ module Vatras.Util.AuxProofs where
 open import Level using (Level)
 open import Function using (id; _∘_)
 
-open import Data.Bool using (Bool; false; true; if_then_else_)
+open import Data.Bool using (Bool; false; true; if_then_else_; not)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.Nat using (ℕ; zero; suc; NonZero; _≡ᵇ_; _⊓_; _+_; _∸_; _<_; _≤_; s≤s; z≤n)
 open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0)
@@ -90,6 +90,11 @@ if-swap : ∀ {A : Set} (x y : Bool) (a b : A)
 if-swap false _ _ _ = refl
 if-swap true false _ _ = refl
 if-swap true true _ _ = refl
+
+if-flip : ∀ {ℓ} {A : Set ℓ} (x : Bool) (a b : A)
+  → (if not x then a else b) ≡ (if x then b else a)
+if-flip false a b = refl
+if-flip true  a b = refl
 
 ----- Properties of Vectors
 

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -6,7 +6,7 @@ open import Function using (id; _∘_)
 open import Data.Bool using (Bool; false; true; if_then_else_; not; _∧_)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.Nat using (ℕ; zero; suc; NonZero; _≡ᵇ_; _⊓_; _+_; _∸_; _<_; _≤_; s≤s; z≤n)
-open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0)
+open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0; m≤n+m)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.List.Properties using (length-++)
 open import Data.Product using (_×_; _,_)
@@ -17,7 +17,7 @@ import Relation.Binary.PropositionalEquality as Eq
 open Eq using (_≡_; _≢_; _≗_; refl)
 open Eq.≡-Reasoning
 
--- Some logic helpers
+----- Some logic helpers
 
 true≢false : ∀ {a : Bool}
   → a ≡ true
@@ -25,11 +25,19 @@ true≢false : ∀ {a : Bool}
   → a ≢ false
 true≢false refl ()
 
------ Some aritmetic properties
+----- Some arithmetic properties
+-- TODO: Contribute some of these functions to STL
 
-n≡ᵇn : ∀ (n : ℕ) → (n ≡ᵇ n) ≡ true
-n≡ᵇn zero = refl
-n≡ᵇn (suc n) = n≡ᵇn n
+≡ᵇ-refl : ∀ (n : ℕ) → (n ≡ᵇ n) ≡ true
+≡ᵇ-refl zero = refl
+≡ᵇ-refl (suc n) = ≡ᵇ-refl n
+
+≡ᵇ-< : ∀ {m n} → n < m → (m ≡ᵇ n) ≡ false
+≡ᵇ-< {.(suc _)} {zero}  (s≤s _) = refl
+≡ᵇ-< {suc m}    {suc n} (s≤s x) = ≡ᵇ-< x
+
+m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
+m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
 
 <-cong-+ˡ : ∀ {m n} (a : ℕ) → m < n → a + m < a + n
 <-cong-+ˡ zero x = x
@@ -68,6 +76,14 @@ n<m→m≡ᵇn {suc n} (s≤s n<m) = n<m→m≡ᵇn n<m
 n∸1+m<n∸m : {n m : ℕ} → suc m ≤ n → n ∸ suc m < n ∸ m
 n∸1+m<n∸m {suc n} {zero} (s≤s m<n) = n<1+n n
 n∸1+m<n∸m {suc n} {suc m} (s≤s m<n) = n∸1+m<n∸m m<n
+
+∸-suc : ∀ n m → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+∸-suc n         .zero       z≤n = refl
+∸-suc (suc n) (suc m) (s≤s n≤m) = ∸-suc n m n≤m
+
+≤-sucʳ : ∀ {m n} → m ≤ n → m ≤ suc n
+≤-sucʳ z≤n       = z≤n
+≤-sucʳ (s≤s leq) = s≤s (≤-sucʳ leq)
 
 ----- Properties of if_then_else
 -- TODO: Contribute to STL

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -3,7 +3,7 @@ module Vatras.Util.AuxProofs where
 open import Level using (Level)
 open import Function using (id; _∘_)
 
-open import Data.Bool using (Bool; false; true; if_then_else_; not)
+open import Data.Bool using (Bool; false; true; if_then_else_; not; _∧_)
 open import Data.Fin using (Fin; zero; suc; fromℕ<)
 open import Data.Nat using (ℕ; zero; suc; NonZero; _≡ᵇ_; _⊓_; _+_; _∸_; _<_; _≤_; s≤s; z≤n)
 open import Data.Nat.Properties using (n<1+n; m⊓n≤m; +-comm; +-∸-comm; n∸n≡0)
@@ -95,6 +95,11 @@ if-flip : ∀ {ℓ} {A : Set ℓ} (x : Bool) (a b : A)
   → (if not x then a else b) ≡ (if x then b else a)
 if-flip false a b = refl
 if-flip true  a b = refl
+
+if-∧ : ∀ {ℓ} {A : Set ℓ} (x y : Bool) (a b : A)
+  → (if x ∧ y then a else b) ≡ (if x then (if y then a else b) else b)
+if-∧ false _ _ _ = refl
+if-∧ true  _ _ _ = refl
 
 ----- Properties of Vectors
 

--- a/src/Vatras/Util/AuxProofs.agda
+++ b/src/Vatras/Util/AuxProofs.agda
@@ -39,6 +39,10 @@ true≢false refl ()
 m+n≢ᵇn : ∀ i n → (suc i + n ≡ᵇ n) ≡ false
 m+n≢ᵇn i n = ≡ᵇ-< (s≤s (m≤n+m n i))
 
+∸-suc : ∀ {n m} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+∸-suc z≤n = refl
+∸-suc (s≤s n≤m) = ∸-suc n≤m
+
 ≤-suc : ∀ {m n} → m ≤ n → m ≤ suc n
 ≤-suc z≤n       = z≤n
 ≤-suc (s≤s leq) = s≤s (≤-suc leq)
@@ -76,10 +80,6 @@ n<m→m≡ᵇn {suc n} (s≤s n<m) = n<m→m≡ᵇn n<m
 n∸1+m<n∸m : {n m : ℕ} → suc m ≤ n → n ∸ suc m < n ∸ m
 n∸1+m<n∸m {suc n} {zero} (s≤s m<n) = n<1+n n
 n∸1+m<n∸m {suc n} {suc m} (s≤s m<n) = n∸1+m<n∸m m<n
-
-∸-suc : ∀ n m → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-∸-suc n         .zero       z≤n = refl
-∸-suc (suc n) (suc m) (s≤s n≤m) = ∸-suc n m n≤m
 
 ----- Properties of if_then_else
 -- TODO: Contribute to STL

--- a/src/Vatras/Util/NonEmptyTraversable.agda
+++ b/src/Vatras/Util/NonEmptyTraversable.agda
@@ -1,5 +1,6 @@
 {-|
 Traversable instance on non-empty lists.
+part of the STL now: Data.List.NonEmpty.Effectful
 -}
 module Vatras.Util.NonEmptyTraversable where
 


### PR DESCRIPTION
This PR contains
- a formalization of Variation Trees,
- a proof for soundness of Variation Trees,
- a proof for completeness of Variation Trees,
- Formula ADTs (i.e., ADTs in which choices are annotated with formulas),
- propositional logic,
- forests of rose trees as variants,
- default atom definitions for strings and natural numbers as part of issue #76,
- some minor refactorings and extensions for these proofs, in particular in our `AuxProofs` module