### PR TITLE
Fix CI warning

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         key: nix-${{ hashFiles('.github/workflows/check.yml', 'default.nix', 'nix/**') }}
         nix_file: nix/github-workflow-dependencies.nix
+    - name: Setup the environment
+      # Supress a warning about missing channels by using the shell from the environment
+      run: echo NIX_BUILD_SHELL="$(which bash)" >> "$GITHUB_ENV"
     - name: Check Agda files
       run: nix-shell --run './scripts/check-all.sh github-action'
     - name: Check for sources of inconsistencies


### PR DESCRIPTION
After a cache hit, there are no channels installed. When running `nix-shell`, it tries to execute bash from a nixpkgs in a channel, fails to do so and falls back to the bash in the environment. Unfortunately, the warning message is quite misleading:
```
warning: Nix search path entry 'channel:' cannot be downloaded, ignoring
error:
       … while calling the 'import' builtin

         at «string»:1:2:

            1| (import <nixpkgs> {}).bashInteractive
             |  ^

       … while realising the context of a path

       … while calling the 'findFile' builtin

         at «string»:1:9:

            1| (import <nixpkgs> {}).bashInteractive
             |         ^

       error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)
will use bash from your environment
```
As there is no further output it looks like a failed CI run although the exit code was zero and thus the CI is considered successful (which is indeed correct).

This fix explicitly uses the environment if no channels are installed. Note that channels are still used if available. In particular, the shell used when the cache hits is the pre-installed one but on cache misses the shell is taken from nixpkgs. Both shells are bash but the versions might differ.